### PR TITLE
fix: wire phase advancement and unify history in TwoStageSessionManager

### DIFF
--- a/backend/src/two_stage_session.py
+++ b/backend/src/two_stage_session.py
@@ -29,7 +29,6 @@ class PhaseEnum(enum.Enum):
     HYPE = "hype"
     CLIMAX = "climax"
 
-# TODO(Task4): wire _phase into receive_audio via _build_stage1_system
 PHASE_CONFIG = {
     PhaseEnum.INTRO: {
         "system": (
@@ -101,15 +100,21 @@ class TwoStageSessionManager:
                 httpx_async_client=httpx.AsyncClient(http2=False, timeout=30),
             ),
         )
-        self._history: list[dict] = []  # Gemini API format: {"role": ..., "parts": [...]}
-        self._text_history: list[dict] = []  # {"user": str, "model": str} text-only
+        self._history: list[dict] = []  # Gemini API format: {"role": ..., "parts": [{"text": ...}]}
         self._phase: PhaseEnum = PhaseEnum.INTRO
         self._phase_turns: int = 0
         self._lock = asyncio.Lock()
 
     def _build_stage1_system(self) -> str:
         base = PHASE_CONFIG[self._phase]["system"]
-        recent = self._text_history[-4:]
+        # _history は [user, model, user, model, ...] の交互構造
+        pairs = [
+            {"user": self._history[i]["parts"][0]["text"],
+             "model": self._history[i + 1]["parts"][0]["text"]}
+            for i in range(0, len(self._history) - 1, 2)
+            if self._history[i]["role"] == "user" and self._history[i + 1]["role"] == "model"
+        ]
+        recent = pairs[-4:]
         if not recent:
             return base
         history_lines = "\n".join(
@@ -156,7 +161,7 @@ class TwoStageSessionManager:
                 "<user_said>相手が言ったことを1文で要約</user_said>\n"
                 "<response>占い師としての応答を2文</response>"
             )
-            contents1 = [
+            contents1 = self._history + [
                 {"role": "user", "parts": [audio_part, {"text": stage1_prompt}]}
             ]
             try:
@@ -206,12 +211,13 @@ class TwoStageSessionManager:
                 stage2_url = None
 
             self._history.extend([
-                {"role": "user", "parts": [audio_part]},
+                {"role": "user", "parts": [{"text": user_summary}]},
                 {"role": "model", "parts": [{"text": f"{stage1_text} {stage2_text}"}]},
             ])
             self._history = self._history[-12:]
-            self._text_history.append({"user": user_summary, "model": f"{stage1_text} {stage2_text}"})
-            self._text_history = self._text_history[-6:]
+
+            self._phase_turns += 1
+            self._advance_phase_if_needed(snapshot["level"])
 
             yield {"type": "stage2", "text": stage2_text, "audio_url": stage2_url}
             yield {"type": "turn_end"}


### PR DESCRIPTION
## Summary

- **フェーズ進行バグ修正**: `_phase_turns` のインクリメントと `_advance_phase_if_needed` の呼び出しが `receive_audio` に存在しなかったため、フェーズが永遠に INTRO のままだった問題を修正
- **Stage 1 に会話履歴を渡す**: `contents1` に `self._history` を含めるよう修正し、過去ターンの会話がシステムプロンプトのテキストだけでなく API messages としても渡されるようになった
- **履歴から音声データを除去**: `_history` に `audio_part`（base64音声）ではなく `user_summary`（テキスト要約）を保存するよう変更し、トークン消費を削減
- **`_text_history` を廃止**: `_history` に統合し、`_build_stage1_system()` が `_history` のペア構造から直接読むように変更。重複管理を解消

## Test plan

- [ ] セッション開始後、複数ターン会話して INTRO → CORE → HYPE → CLIMAX とフェーズが進むことを確認
- [ ] Stage 1 / Stage 2 の応答が前ターンの会話内容を踏まえていることを確認
- [ ] `_history` にテキストのみが保存され、音声データが残らないことをデバッグログで確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)