### PR TITLE
feat: Live API WebSocket streaming with auto-VAD

### DIFF
--- a/backend/src/agitation_engine.py
+++ b/backend/src/agitation_engine.py
@@ -55,3 +55,9 @@ class AgitationEngine:
         result = {"level": current, "trend": self.trend}
         self._previous_level = float(current)
         return result
+
+    def snapshot_window(self, from_ts: float, to_ts: float) -> dict:
+        """指定期間内のパルスから level/peak/trend を算出。_previous_level は更新しない。"""
+        pulses_in_window = [t for t in self._pulses if from_ts <= t <= to_ts]
+        level = min(100, int(len(pulses_in_window) / self.max_pulses * 100))
+        return {"level": level, "peak": level, "trend": self._calc_trend(level)}

--- a/backend/src/agitation_engine.py
+++ b/backend/src/agitation_engine.py
@@ -33,15 +33,17 @@ class AgitationEngine:
         self._cleanup()
         return min(100, int(len(self._pulses) / self.max_pulses * 100))
 
-    @property
-    def trend(self) -> str:
-        current = self.level
-        diff = current - self._previous_level
+    def _calc_trend(self, level: int) -> str:
+        diff = level - self._previous_level
         if diff > 10:
             return "rising"
         elif diff < -10:
             return "falling"
         return "stable"
+
+    @property
+    def trend(self) -> str:
+        return self._calc_trend(self.level)
 
     def is_spike(self) -> bool:
         """前回比+30以上で急上昇と判定"""

--- a/backend/src/agitation_server.py
+++ b/backend/src/agitation_server.py
@@ -19,6 +19,16 @@ def get_agitation():
     return snap
 
 
+@app.get("/agitation/window")
+def get_agitation_window(from_ts: float, to_ts: float):
+    snap = engine.snapshot_window(from_ts, to_ts)
+    print(
+        f"[Agitation] window({from_ts:.1f},{to_ts:.1f}) → level={snap['level']}%, trend={snap['trend']}",
+        flush=True,
+    )
+    return snap
+
+
 @app.post("/pulse")
 def post_pulse():
     engine.record_pulse()

--- a/backend/src/live_session.py
+++ b/backend/src/live_session.py
@@ -89,13 +89,21 @@ class LiveSessionManager:
             self._ctx = None
             self._session = None
 
-    async def send_audio(self, pcm_bytes: bytes) -> None:
-        """PCM 16kHz mono int16 を Live API へ送信。"""
+    async def send_audio_chunk(self, pcm_bytes: bytes) -> None:
+        """PCM 16kHz mono int16 の 1 chunk を Live API へ送信。"""
         self._ai_speak_start = None
         await self._session.send_realtime_input(
             audio=types.Blob(data=pcm_bytes, mime_type="audio/pcm;rate=16000")
         )
+
+    async def flush_input_audio(self) -> None:
+        """入力音声の一区切りを Live API へ通知する。"""
         await self._session.send_realtime_input(audio_stream_end=True)
+
+    async def send_audio(self, pcm_bytes: bytes) -> None:
+        """互換用: PCM を 1 回送って flush する。"""
+        await self.send_audio_chunk(pcm_bytes)
+        await self.flush_input_audio()
 
     async def receive(self) -> AsyncGenerator[dict, None]:
         """

--- a/backend/src/live_session.py
+++ b/backend/src/live_session.py
@@ -104,12 +104,13 @@ class LiveSessionManager:
           {"type": "turn_complete"}
         """
         async for response in self._session.receive():
-            if response.data:
+            audio_data = self._extract_audio_data(response)
+            if audio_data:
                 if self._ai_speak_start is None:
                     self._ai_speak_start = time.time()
                 yield {
                     "type": "audio_chunk",
-                    "data": base64.b64encode(response.data).decode(),
+                    "data": base64.b64encode(audio_data).decode(),
                 }
 
             if response.tool_call:
@@ -119,6 +120,21 @@ class LiveSessionManager:
             if response.server_content and response.server_content.turn_complete:
                 yield {"type": "turn_complete"}
                 self._ai_speak_start = None
+
+    def _extract_audio_data(self, response) -> bytes | None:
+        """Live API レスポンスから音声バイト列を取り出す。"""
+        if getattr(response, "data", None):
+            return response.data
+
+        server_content = getattr(response, "server_content", None)
+        model_turn = getattr(server_content, "model_turn", None)
+        parts = getattr(model_turn, "parts", None) or []
+        for part in parts:
+            inline_data = getattr(part, "inline_data", None)
+            data = getattr(inline_data, "data", None)
+            if data:
+                return data
+        return None
 
     async def _handle_tool_call(self, call) -> None:
         """get_agitation tool call を処理してラズパイに問い合わせ、結果を返す。"""

--- a/backend/src/live_session.py
+++ b/backend/src/live_session.py
@@ -72,6 +72,11 @@ class LiveSessionManager:
             response_modalities=["AUDIO"],
             system_instruction=SYSTEM_INSTRUCTION,
             tools=[types.Tool(function_declarations=[GET_AGITATION_DECLARATION])],
+            input_audio_transcription=types.AudioTranscriptionConfig(),
+            realtime_input_config=types.RealtimeInputConfig(
+                activity_handling=types.ActivityHandling.START_OF_ACTIVITY_INTERRUPTS,
+                turn_coverage=types.TurnCoverage.TURN_INCLUDES_ONLY_ACTIVITY,
+            ),
             context_window_compression=types.ContextWindowCompressionConfig(
                 trigger_tokens=100000,
                 sliding_window=types.SlidingWindow(target_tokens=80000),
@@ -112,7 +117,11 @@ class LiveSessionManager:
 
     async def flush_input_audio(self) -> None:
         """入力音声の一区切りを Live API へ通知する。"""
-        await self._session.send_realtime_input(audio_stream_end=True)
+        await self._session.send_realtime_input(activity_end=types.ActivityEnd())
+
+    async def start_input_audio(self) -> None:
+        """入力音声の開始を Live API へ通知する。"""
+        await self._session.send_realtime_input(activity_start=types.ActivityStart())
 
     async def send_audio(self, pcm_bytes: bytes) -> None:
         """互換用: PCM を 1 回送って flush する。"""
@@ -124,40 +133,88 @@ class LiveSessionManager:
         受信イベントを yield する:
           {"type": "audio_chunk", "data": "<base64 PCM 24kHz>"}
           {"type": "turn_complete"}
-        """
-        async for response in self._session.receive():
-            audio_data = self._extract_audio_data(response)
-            if audio_data:
-                if self._ai_speak_start is None:
-                    self._ai_speak_start = time.time()
-                self._received_audio_chunks += 1
-                print(
-                    f"[LiveSession] receive_audio_chunk count={self._received_audio_chunks} "
-                    f"bytes={len(audio_data)} ts={time.time():.3f}",
-                    flush=True,
-                )
-                yield {
-                    "type": "audio_chunk",
-                    "data": base64.b64encode(audio_data).decode(),
-                }
 
-            if response.tool_call:
-                for call in response.tool_call.function_calls:
-                    self._tool_call_count += 1
+        google-genai SDK の session.receive() は 1 ターン分で終了するため、
+        while True でターンをまたいで再呼び出しする。
+        """
+        while True:
+            got_response = False
+            async for response in self._session.receive():
+                got_response = True
+                server_content = getattr(response, "server_content", None)
+                should_emit_turn_complete = False
+                input_transcription = getattr(server_content, "input_transcription", None)
+                input_text = getattr(input_transcription, "text", None)
+                if input_text:
                     print(
-                        f"[LiveSession] receive_tool_call count={self._tool_call_count} "
-                        f"name={call.name} ts={time.time():.3f}",
+                        f"[LiveSession] input_transcription text={input_text!r} ts={time.time():.3f}",
                         flush=True,
                     )
-                    await self._handle_tool_call(call)
+                if server_content:
+                    waiting_for_input = getattr(server_content, "waiting_for_input", None)
+                    if waiting_for_input is not None:
+                        print(
+                            f"[LiveSession] waiting_for_input value={waiting_for_input} ts={time.time():.3f}",
+                            flush=True,
+                        )
+                    interrupted = getattr(server_content, "interrupted", None)
+                    if interrupted:
+                        print(
+                            f"[LiveSession] interrupted ts={time.time():.3f}",
+                            flush=True,
+                        )
+                    generation_complete = getattr(server_content, "generation_complete", None)
+                    if generation_complete:
+                        print(
+                            f"[LiveSession] generation_complete ts={time.time():.3f}",
+                            flush=True,
+                        )
+                        should_emit_turn_complete = True
+                    turn_complete_reason = getattr(server_content, "turn_complete_reason", None)
+                    if turn_complete_reason:
+                        print(
+                            f"[LiveSession] turn_complete_reason value={turn_complete_reason} "
+                            f"ts={time.time():.3f}",
+                            flush=True,
+                        )
+                audio_data = self._extract_audio_data(response)
+                if audio_data:
+                    if self._ai_speak_start is None:
+                        self._ai_speak_start = time.time()
+                    self._received_audio_chunks += 1
+                    print(
+                        f"[LiveSession] receive_audio_chunk count={self._received_audio_chunks} "
+                        f"bytes={len(audio_data)} ts={time.time():.3f}",
+                        flush=True,
+                    )
+                    yield {
+                        "type": "audio_chunk",
+                        "data": base64.b64encode(audio_data).decode(),
+                    }
 
-            if response.server_content and response.server_content.turn_complete:
-                print(
-                    f"[LiveSession] receive_turn_complete ts={time.time():.3f}",
-                    flush=True,
-                )
-                yield {"type": "turn_complete"}
-                self._ai_speak_start = None
+                if response.tool_call:
+                    for call in response.tool_call.function_calls:
+                        self._tool_call_count += 1
+                        print(
+                            f"[LiveSession] receive_tool_call count={self._tool_call_count} "
+                            f"name={call.name} ts={time.time():.3f}",
+                            flush=True,
+                        )
+                        await self._handle_tool_call(call)
+
+                if server_content and server_content.turn_complete:
+                    should_emit_turn_complete = True
+
+                if should_emit_turn_complete:
+                    print(
+                        f"[LiveSession] receive_turn_complete ts={time.time():.3f}",
+                        flush=True,
+                    )
+                    yield {"type": "turn_complete"}
+                    self._ai_speak_start = None
+
+            if not got_response:
+                break
 
     def _extract_audio_data(self, response) -> bytes | None:
         """Live API レスポンスから音声バイト列を取り出す。"""

--- a/backend/src/live_session.py
+++ b/backend/src/live_session.py
@@ -14,7 +14,7 @@ import httpx
 from google import genai
 from google.genai import types
 
-MODEL = "gemini-2.5-flash-live"
+MODEL = "gemini-2.5-flash-native-audio-preview-12-2025"
 AGITATION_API_URL = os.getenv("AGITATION_API_URL", "")
 
 SYSTEM_INSTRUCTION = """\
@@ -95,6 +95,7 @@ class LiveSessionManager:
         await self._session.send_realtime_input(
             audio=types.Blob(data=pcm_bytes, mime_type="audio/pcm;rate=16000")
         )
+        await self._session.send_realtime_input(audio_stream_end=True)
 
     async def receive(self) -> AsyncGenerator[dict, None]:
         """

--- a/backend/src/live_session.py
+++ b/backend/src/live_session.py
@@ -1,0 +1,150 @@
+"""
+Gemini Live API を使った占いセッション管理。
+- 1ターン = 1つの自然な応答（stage1/stage2 の区別なし）
+- get_agitation tool を AI が自律的に呼ぶ
+"""
+from __future__ import annotations
+
+import base64
+import os
+import time
+from typing import AsyncGenerator
+
+import httpx
+from google import genai
+from google.genai import types
+
+MODEL = "gemini-2.5-flash-live"
+AGITATION_API_URL = os.getenv("AGITATION_API_URL", "")
+
+SYSTEM_INSTRUCTION = """\
+あなたはAI手相占い師「ぱむぱむ」です。
+
+【基本姿勢】
+手の感情線・運命線・頭脳線・生命線を具体的に言及しながら語る。
+断言は避け「〜ではないですか」「〜が見えます」という仮説として語る。
+神秘的かつ低いトーンで、2〜3文で語る。
+
+【get_agitation ツールの使い方（最重要）】
+- 毎ターン必ず1回呼び出すこと
+- 呼び出すタイミングは「感情の核心に近づいた」と感じた瞬間（ターンの中盤〜後半）
+- 呼び出す前に一般的な読みを展開し、結果を見てから核心を突く
+- すぐに「センサーが〜」とは言わない。「体が正直に答えています」程度に留める
+
+【出力】
+2〜3文、必ず問いかけで締める。
+"""
+
+GET_AGITATION_DECLARATION = types.FunctionDeclaration(
+    name="get_agitation",
+    description=(
+        "ユーザーの手の振動センサーから身体的動揺度を読み取る。"
+        "占いの重要なタイミング（感情の核心に触れる直前）で呼び出すこと。"
+        "呼び出すタイミング自体が演出の一部。毎ターン1回は必ず呼び出すこと。"
+    ),
+    parameters=types.Schema(type=types.Type.OBJECT, properties={}),
+)
+
+
+class LiveSessionManager:
+    """Gemini Live API を使った占いセッション管理。"""
+
+    def __init__(
+        self,
+        agitation_api_url: str = AGITATION_API_URL,
+        client: genai.Client | None = None,
+    ):
+        self.agitation_api_url = agitation_api_url
+        self._client = client
+        self._session = None
+        self._ai_speak_start: float | None = None
+        self._text_history: list[dict] = []
+        self._ctx = None
+
+    async def connect(self) -> None:
+        """Live API セッションを確立する。"""
+        if self._client is None:
+            self._client = genai.Client(api_key=os.getenv("GEMINI_API_KEY"))
+        config = types.LiveConnectConfig(
+            response_modalities=["AUDIO"],
+            system_instruction=SYSTEM_INSTRUCTION,
+            tools=[types.Tool(function_declarations=[GET_AGITATION_DECLARATION])],
+            context_window_compression=types.ContextWindowCompressionConfig(
+                trigger_tokens=100000,
+                sliding_window=types.SlidingWindow(target_tokens=80000),
+            ),
+            speech_config=types.SpeechConfig(
+                voice_config=types.VoiceConfig(
+                    prebuilt_voice_config=types.PrebuiltVoiceConfig(voice_name="Kore")
+                )
+            ),
+        )
+        self._ctx = self._client.aio.live.connect(model=MODEL, config=config)
+        self._session = await self._ctx.__aenter__()
+
+    async def disconnect(self) -> None:
+        """セッションを終了する。"""
+        if self._ctx:
+            await self._ctx.__aexit__(None, None, None)
+            self._ctx = None
+            self._session = None
+
+    async def send_audio(self, pcm_bytes: bytes) -> None:
+        """PCM 16kHz mono int16 を Live API へ送信。"""
+        self._ai_speak_start = None
+        await self._session.send_realtime_input(
+            audio=types.Blob(data=pcm_bytes, mime_type="audio/pcm;rate=16000")
+        )
+
+    async def receive(self) -> AsyncGenerator[dict, None]:
+        """
+        受信イベントを yield する:
+          {"type": "audio_chunk", "data": "<base64 PCM 24kHz>"}
+          {"type": "turn_complete"}
+        """
+        async for response in self._session.receive():
+            if response.data:
+                if self._ai_speak_start is None:
+                    self._ai_speak_start = time.time()
+                yield {
+                    "type": "audio_chunk",
+                    "data": base64.b64encode(response.data).decode(),
+                }
+
+            if response.tool_call:
+                for call in response.tool_call.function_calls:
+                    await self._handle_tool_call(call)
+
+            if response.server_content and response.server_content.turn_complete:
+                yield {"type": "turn_complete"}
+                self._ai_speak_start = None
+
+    async def _handle_tool_call(self, call) -> None:
+        """get_agitation tool call を処理してラズパイに問い合わせ、結果を返す。"""
+        from_ts = self._ai_speak_start if self._ai_speak_start else time.time() - 3.0
+        to_ts = time.time()
+        snap = await self._fetch_agitation_window(from_ts, to_ts)
+        await self._session.send_tool_response(
+            function_responses=[
+                types.FunctionResponse(
+                    id=call.id,
+                    name=call.name,
+                    response=snap,
+                )
+            ]
+        )
+
+    async def _fetch_agitation_window(self, from_ts: float, to_ts: float) -> dict:
+        """ラズパイの /agitation/window を HTTP 呼び出し。失敗時はデフォルト値を返す。"""
+        if not self.agitation_api_url:
+            return {"level": 0, "peak": 0, "trend": "stable"}
+        try:
+            async with httpx.AsyncClient(timeout=2.0) as client:
+                response = await client.get(
+                    f"{self.agitation_api_url}/agitation/window",
+                    params={"from_ts": from_ts, "to_ts": to_ts},
+                )
+                return response.json()
+        except Exception as exc:
+            print(f"[LiveSession] agitation fetch error: {exc}", flush=True)
+            return {"level": 0, "peak": 0, "trend": "stable"}

--- a/backend/src/live_session.py
+++ b/backend/src/live_session.py
@@ -60,6 +60,9 @@ class LiveSessionManager:
         self._ai_speak_start: float | None = None
         self._text_history: list[dict] = []
         self._ctx = None
+        self._sent_audio_chunks = 0
+        self._received_audio_chunks = 0
+        self._tool_call_count = 0
 
     async def connect(self) -> None:
         """Live API セッションを確立する。"""
@@ -84,6 +87,11 @@ class LiveSessionManager:
 
     async def disconnect(self) -> None:
         """セッションを終了する。"""
+        print(
+            f"[LiveSession] disconnect ts={time.time():.3f} "
+            f"sent_chunks={self._sent_audio_chunks} received_chunks={self._received_audio_chunks}",
+            flush=True,
+        )
         if self._ctx:
             await self._ctx.__aexit__(None, None, None)
             self._ctx = None
@@ -92,6 +100,12 @@ class LiveSessionManager:
     async def send_audio_chunk(self, pcm_bytes: bytes) -> None:
         """PCM 16kHz mono int16 の 1 chunk を Live API へ送信。"""
         self._ai_speak_start = None
+        self._sent_audio_chunks += 1
+        print(
+            f"[LiveSession] send_audio_chunk count={self._sent_audio_chunks} "
+            f"bytes={len(pcm_bytes)} ts={time.time():.3f}",
+            flush=True,
+        )
         await self._session.send_realtime_input(
             audio=types.Blob(data=pcm_bytes, mime_type="audio/pcm;rate=16000")
         )
@@ -116,6 +130,12 @@ class LiveSessionManager:
             if audio_data:
                 if self._ai_speak_start is None:
                     self._ai_speak_start = time.time()
+                self._received_audio_chunks += 1
+                print(
+                    f"[LiveSession] receive_audio_chunk count={self._received_audio_chunks} "
+                    f"bytes={len(audio_data)} ts={time.time():.3f}",
+                    flush=True,
+                )
                 yield {
                     "type": "audio_chunk",
                     "data": base64.b64encode(audio_data).decode(),
@@ -123,9 +143,19 @@ class LiveSessionManager:
 
             if response.tool_call:
                 for call in response.tool_call.function_calls:
+                    self._tool_call_count += 1
+                    print(
+                        f"[LiveSession] receive_tool_call count={self._tool_call_count} "
+                        f"name={call.name} ts={time.time():.3f}",
+                        flush=True,
+                    )
                     await self._handle_tool_call(call)
 
             if response.server_content and response.server_content.turn_complete:
+                print(
+                    f"[LiveSession] receive_turn_complete ts={time.time():.3f}",
+                    flush=True,
+                )
                 yield {"type": "turn_complete"}
                 self._ai_speak_start = None
 

--- a/backend/src/main.py
+++ b/backend/src/main.py
@@ -1,48 +1,38 @@
-# backend/src/main.py
 # Docker コンテナで IPv6 が到達不能な環境向け: DNS 解決で IPv4 のみ返すように上書き
 import socket as _socket
+
 _orig_getaddrinfo = _socket.getaddrinfo
-def _ipv4_only(host, port, family=0, *a, **kw):
-    results = _orig_getaddrinfo(host, port, family, *a, **kw)
-    ipv4 = [r for r in results if r[0] == _socket.AF_INET]
+
+
+def _ipv4_only(host, port, family=0, *args, **kwargs):
+    results = _orig_getaddrinfo(host, port, family, *args, **kwargs)
+    ipv4 = [result for result in results if result[0] == _socket.AF_INET]
     return ipv4 if ipv4 else results
+
+
 _socket.getaddrinfo = _ipv4_only
 
-"""
-PalmPalm バックエンド（FastAPI）
-
-エンドポイント:
-  GET  /health    - ヘルスチェック
-  POST /api/audio - ユーザー音声 → stage1 → stage2 → turn_end
-
-環境変数:
-  GEMINI_API_KEY      - Gemini API キー
-  GEMINI_MODEL        - テキスト生成モデル (default: gemini-2.5-flash)
-  AGITATION_API_URL   - ラズパイの agitation API ベース URL (例: http://raspberrypi.local:8001)
-  STAGE2_LEAD_SECONDS - stage1 終了 N 秒前に stage2 生成開始 (default: 3)
-"""
 import json
+import uuid
 
-from fastapi import FastAPI, Request
+from dotenv import load_dotenv
+from fastapi import FastAPI, HTTPException, Request
 from fastapi.middleware.cors import CORSMiddleware
 from fastapi.responses import StreamingResponse
-from fastapi.staticfiles import StaticFiles
-from dotenv import load_dotenv
 
-from .two_stage_session import TwoStageSessionManager
+from .live_session import LiveSessionManager
 
 load_dotenv()
-
-gemini = TwoStageSessionManager()
 
 app = FastAPI()
 app.add_middleware(
     CORSMiddleware,
     allow_origins=["*"],
-    allow_methods=["GET", "POST", "OPTIONS"],
+    allow_methods=["GET", "POST", "DELETE", "OPTIONS"],
     allow_headers=["*"],
 )
-app.mount("/audio", StaticFiles(directory="assets/audio"), name="audio")
+
+sessions: dict[str, LiveSessionManager] = {}
 
 
 def _sse(event: dict) -> str:
@@ -54,15 +44,29 @@ async def health():
     return {"status": "ok"}
 
 
+@app.post("/api/session/start")
+async def session_start():
+    """Live API セッションを確立し session_id を返す。"""
+    session_id = str(uuid.uuid4())
+    manager = LiveSessionManager()
+    await manager.connect()
+    sessions[session_id] = manager
+    print(f"[Main] session started: {session_id}", flush=True)
+    return {"session_id": session_id}
+
+
 @app.post("/api/audio")
-async def receive_audio(request: Request):
-    """ユーザー音声を受け取り stage1→stage2 を SSE で返す。"""
-    audio_bytes = await request.body()
-    raw_ct = request.headers.get("content-type", "audio/webm")
-    mime_type = raw_ct.split(";")[0].strip() or "audio/webm"
+async def receive_audio(session_id: str, request: Request):
+    """PCM 音声を受け取り、Live API 経由で応答を SSE でストリーム返却。"""
+    manager = sessions.get(session_id)
+    if not manager:
+        raise HTTPException(status_code=404, detail="session not found")
+
+    pcm_bytes = await request.body()
+    await manager.send_audio(pcm_bytes)
 
     async def generate():
-        async for event in gemini.receive_audio(audio_bytes, mime_type):
+        async for event in manager.receive():
             yield _sse(event)
 
     return StreamingResponse(
@@ -70,3 +74,13 @@ async def receive_audio(request: Request):
         media_type="text/event-stream",
         headers={"Cache-Control": "no-cache", "X-Accel-Buffering": "no"},
     )
+
+
+@app.delete("/api/session")
+async def session_delete(session_id: str):
+    """セッションを終了・破棄する。"""
+    manager = sessions.pop(session_id, None)
+    if manager:
+        await manager.disconnect()
+    print(f"[Main] session deleted: {session_id}", flush=True)
+    return {"ok": True}

--- a/backend/src/main.py
+++ b/backend/src/main.py
@@ -2,6 +2,7 @@
 import asyncio
 import json
 import socket as _socket
+import traceback
 
 from dotenv import load_dotenv
 from fastapi import FastAPI, WebSocket, WebSocketDisconnect
@@ -38,7 +39,10 @@ async def health():
 
 @app.websocket("/ws/session")
 async def ws_session(websocket: WebSocket):
+    binary_frame_count = 0
+    text_frame_count = 0
     await websocket.accept()
+    print("[WebSocket] accepted /ws/session", flush=True)
     manager = LiveSessionManager()
     await manager.connect()
     await websocket.send_json({"type": "session_ready"})
@@ -50,16 +54,32 @@ async def ws_session(websocket: WebSocket):
             if message["type"] == "websocket.disconnect":
                 break
             if message.get("bytes") is not None:
+                binary_frame_count += 1
+                print(
+                    f"[WebSocket] received binary_frame count={binary_frame_count} "
+                    f"bytes={len(message['bytes'])}",
+                    flush=True,
+                )
                 await manager.send_audio_chunk(message["bytes"])
             if message.get("text") is not None:
+                text_frame_count += 1
                 payload = json.loads(message["text"])
+                print(
+                    f"[WebSocket] received text_frame count={text_frame_count} "
+                    f"type={payload.get('type')}",
+                    flush=True,
+                )
                 if payload.get("type") == "input_audio_end":
                     await manager.flush_input_audio()
                 if payload.get("type") == "session_end":
                     break
     except WebSocketDisconnect:
-        pass
+        print("[WebSocket] disconnected by client", flush=True)
+    except Exception:
+        print("[WebSocket] exception\n" + traceback.format_exc(), flush=True)
+        raise
     finally:
+        print("[WebSocket] closing session", flush=True)
         receive_task.cancel()
         try:
             await receive_task

--- a/backend/src/main.py
+++ b/backend/src/main.py
@@ -1,5 +1,6 @@
 # Docker コンテナで IPv6 が到達不能な環境向け: DNS 解決で IPv4 のみ返すように上書き
 import asyncio
+import json
 import socket as _socket
 
 from dotenv import load_dotenv
@@ -50,6 +51,12 @@ async def ws_session(websocket: WebSocket):
                 break
             if message.get("bytes") is not None:
                 await manager.send_audio_chunk(message["bytes"])
+            if message.get("text") is not None:
+                payload = json.loads(message["text"])
+                if payload.get("type") == "input_audio_end":
+                    await manager.flush_input_audio()
+                if payload.get("type") == "session_end":
+                    break
     except WebSocketDisconnect:
         pass
     finally:

--- a/backend/src/main.py
+++ b/backend/src/main.py
@@ -1,5 +1,12 @@
 # Docker コンテナで IPv6 が到達不能な環境向け: DNS 解決で IPv4 のみ返すように上書き
+import asyncio
 import socket as _socket
+
+from dotenv import load_dotenv
+from fastapi import FastAPI, WebSocket, WebSocketDisconnect
+from fastapi.middleware.cors import CORSMiddleware
+
+from .live_session import LiveSessionManager
 
 _orig_getaddrinfo = _socket.getaddrinfo
 
@@ -12,16 +19,6 @@ def _ipv4_only(host, port, family=0, *args, **kwargs):
 
 _socket.getaddrinfo = _ipv4_only
 
-import json
-import uuid
-
-from dotenv import load_dotenv
-from fastapi import FastAPI, HTTPException, Request
-from fastapi.middleware.cors import CORSMiddleware
-from fastapi.responses import StreamingResponse
-
-from .live_session import LiveSessionManager
-
 load_dotenv()
 
 app = FastAPI()
@@ -32,55 +29,36 @@ app.add_middleware(
     allow_headers=["*"],
 )
 
-sessions: dict[str, LiveSessionManager] = {}
-
-
-def _sse(event: dict) -> str:
-    return f"data: {json.dumps(event, ensure_ascii=False)}\n\n"
-
 
 @app.get("/health")
 async def health():
     return {"status": "ok"}
 
 
-@app.post("/api/session/start")
-async def session_start():
-    """Live API セッションを確立し session_id を返す。"""
-    session_id = str(uuid.uuid4())
+@app.websocket("/ws/session")
+async def ws_session(websocket: WebSocket):
+    await websocket.accept()
     manager = LiveSessionManager()
     await manager.connect()
-    sessions[session_id] = manager
-    print(f"[Main] session started: {session_id}", flush=True)
-    return {"session_id": session_id}
+    await websocket.send_json({"type": "session_ready"})
 
-
-@app.post("/api/audio")
-async def receive_audio(session_id: str, request: Request):
-    """PCM 音声を受け取り、Live API 経由で応答を SSE でストリーム返却。"""
-    manager = sessions.get(session_id)
-    if not manager:
-        raise HTTPException(status_code=404, detail="session not found")
-
-    pcm_bytes = await request.body()
-    await manager.send_audio(pcm_bytes)
-
-    async def generate():
-        async for event in manager.receive():
-            yield _sse(event)
-
-    return StreamingResponse(
-        generate(),
-        media_type="text/event-stream",
-        headers={"Cache-Control": "no-cache", "X-Accel-Buffering": "no"},
-    )
-
-
-@app.delete("/api/session")
-async def session_delete(session_id: str):
-    """セッションを終了・破棄する。"""
-    manager = sessions.pop(session_id, None)
-    if manager:
+    receive_task = asyncio.create_task(_forward_live_events(websocket, manager))
+    try:
+        while True:
+            message = await websocket.receive()
+            if message["type"] == "websocket.disconnect":
+                break
+    except WebSocketDisconnect:
+        pass
+    finally:
+        receive_task.cancel()
+        try:
+            await receive_task
+        except asyncio.CancelledError:
+            pass
         await manager.disconnect()
-    print(f"[Main] session deleted: {session_id}", flush=True)
-    return {"ok": True}
+
+
+async def _forward_live_events(websocket: WebSocket, manager: LiveSessionManager):
+    async for event in manager.receive():
+        await websocket.send_json(event)

--- a/backend/src/main.py
+++ b/backend/src/main.py
@@ -64,15 +64,17 @@ async def ws_session(websocket: WebSocket):
             if message.get("text") is not None:
                 text_frame_count += 1
                 payload = json.loads(message["text"])
+                message_type = payload.get("type")
                 print(
                     f"[WebSocket] received text_frame count={text_frame_count} "
-                    f"type={payload.get('type')}",
+                    f"type={message_type}",
                     flush=True,
                 )
-                if payload.get("type") == "input_audio_end":
-                    await manager.flush_input_audio()
-                if payload.get("type") == "session_end":
+                if message_type == "session_end":
                     break
+                # Binary audio frames are the primary turn input path.
+                if message_type == "input_audio_end":
+                    await manager.flush_input_audio()
     except WebSocketDisconnect:
         print("[WebSocket] disconnected by client", flush=True)
     except Exception:

--- a/backend/src/main.py
+++ b/backend/src/main.py
@@ -48,6 +48,8 @@ async def ws_session(websocket: WebSocket):
             message = await websocket.receive()
             if message["type"] == "websocket.disconnect":
                 break
+            if message.get("bytes") is not None:
+                await manager.send_audio_chunk(message["bytes"])
     except WebSocketDisconnect:
         pass
     finally:

--- a/backend/src/main.py
+++ b/backend/src/main.py
@@ -72,7 +72,7 @@ async def ws_session(websocket: WebSocket):
                 )
                 if message_type == "session_end":
                     break
-                # Binary audio frames are the primary turn input path.
+                # input_audio_end は補助経路として残す（通常は Live VAD が処理）
                 if message_type == "input_audio_end":
                     await manager.flush_input_audio()
     except WebSocketDisconnect:

--- a/backend/tests/test_agitation_engine.py
+++ b/backend/tests/test_agitation_engine.py
@@ -96,3 +96,24 @@ def test_snapshot_updates_previous_level():
         engine.record_pulse()
     engine.snapshot()
     assert engine._previous_level == 50
+
+
+def test_calc_trend_rising():
+    """_calc_trend: diff > 10 で rising"""
+    engine = AgitationEngine(window_seconds=10, max_pulses=20)
+    engine._previous_level = 30
+    assert engine._calc_trend(50) == "rising"
+
+
+def test_calc_trend_falling():
+    """_calc_trend: diff < -10 で falling"""
+    engine = AgitationEngine(window_seconds=10, max_pulses=20)
+    engine._previous_level = 60
+    assert engine._calc_trend(40) == "falling"
+
+
+def test_calc_trend_stable():
+    """_calc_trend: diff が ±10 以内で stable"""
+    engine = AgitationEngine(window_seconds=10, max_pulses=20)
+    engine._previous_level = 50
+    assert engine._calc_trend(55) == "stable"

--- a/backend/tests/test_agitation_engine.py
+++ b/backend/tests/test_agitation_engine.py
@@ -117,3 +117,37 @@ def test_calc_trend_stable():
     engine = AgitationEngine(window_seconds=10, max_pulses=20)
     engine._previous_level = 50
     assert engine._calc_trend(55) == "stable"
+
+
+def test_snapshot_window_counts_pulses_in_range():
+    """指定期間内のパルスのみ集計する"""
+    engine = AgitationEngine(window_seconds=60, max_pulses=10)
+    before = time.time()
+    for _ in range(5):
+        engine.record_pulse()
+    after = time.time()
+    result = engine.snapshot_window(before, after)
+    assert result["level"] == 50
+    assert result["peak"] == 50
+    assert result["trend"] in ("rising", "falling", "stable")
+
+
+def test_snapshot_window_excludes_out_of_range():
+    """ウィンドウ外のパルスは含まない"""
+    engine = AgitationEngine(window_seconds=60, max_pulses=10)
+    for _ in range(5):
+        engine.record_pulse()
+    future = time.time() + 1000
+    result = engine.snapshot_window(future, future + 1)
+    assert result["level"] == 0
+
+
+def test_snapshot_window_does_not_update_previous_level():
+    """snapshot_window は _previous_level を更新しない"""
+    engine = AgitationEngine(window_seconds=60, max_pulses=10)
+    engine._previous_level = 42.0
+    t = time.time()
+    for _ in range(5):
+        engine.record_pulse()
+    engine.snapshot_window(t, time.time())
+    assert engine._previous_level == 42.0

--- a/backend/tests/test_agitation_server.py
+++ b/backend/tests/test_agitation_server.py
@@ -59,3 +59,40 @@ async def test_pulse_returns_ok():
         resp = await ac.post("/pulse")
     assert resp.status_code == 200
     assert resp.json() == {"ok": True}
+
+
+@pytest.mark.asyncio
+async def test_agitation_window_empty():
+    """ウィンドウ内にパルスなし → level=0"""
+    async with AsyncClient(
+        transport=ASGITransport(app=app),
+        base_url="http://test",
+    ) as ac:
+        import time
+
+        t = time.time()
+        resp = await ac.get(f"/agitation/window?from_ts={t}&to_ts={t + 1}")
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["level"] == 0
+    assert "trend" in data
+    assert "peak" in data
+
+
+@pytest.mark.asyncio
+async def test_agitation_window_with_pulses():
+    """ウィンドウ内にパルスあり → level > 0"""
+    import time
+
+    async with AsyncClient(
+        transport=ASGITransport(app=app),
+        base_url="http://test",
+    ) as ac:
+        t_start = time.time()
+        for _ in range(5):
+            await ac.post("/pulse")
+        t_end = time.time()
+        resp = await ac.get(f"/agitation/window?from_ts={t_start}&to_ts={t_end}")
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["level"] > 0

--- a/backend/tests/test_live_session.py
+++ b/backend/tests/test_live_session.py
@@ -23,6 +23,7 @@ class FakeToolCallWrapper:
 class FakeServerContent:
     def __init__(self, audio_data=None, turn_complete=False):
         self.parts = [MagicMock(inline_data=MagicMock(data=audio_data))] if audio_data else []
+        self.model_turn = MagicMock(parts=self.parts) if audio_data else None
         self.turn_complete = turn_complete
 
 
@@ -69,6 +70,26 @@ async def test_receive_yields_audio_chunk(manager):
 
     assert any(event["type"] == "audio_chunk" for event in events)
     assert any(event["type"] == "turn_complete" for event in events)
+
+
+@pytest.mark.asyncio
+async def test_receive_yields_audio_chunk_from_model_turn_parts(manager):
+    """response.data が空でも model_turn.parts.inline_data から audio_chunk を取り出す。"""
+    pcm = b"\x00\x01" * 100
+    responses = [
+        FakeResponse(audio_data=None),
+        FakeResponse(turn_complete=True),
+    ]
+    responses[0].server_content = FakeServerContent(audio_data=pcm)
+    responses[0].data = None
+    fake_session = make_fake_session(responses)
+    manager._session = fake_session
+
+    events = []
+    async for event in manager.receive():
+        events.append(event)
+
+    assert any(event["type"] == "audio_chunk" for event in events)
 
 
 @pytest.mark.asyncio

--- a/backend/tests/test_live_session.py
+++ b/backend/tests/test_live_session.py
@@ -2,6 +2,7 @@
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
+from google.genai import types
 
 from src.live_session import LiveSessionManager
 
@@ -21,24 +22,40 @@ class FakeToolCallWrapper:
 
 
 class FakeServerContent:
-    def __init__(self, audio_data=None, turn_complete=False):
+    def __init__(self, audio_data=None, turn_complete=False, generation_complete=False):
         self.parts = [MagicMock(inline_data=MagicMock(data=audio_data))] if audio_data else []
         self.model_turn = MagicMock(parts=self.parts) if audio_data else None
         self.turn_complete = turn_complete
+        self.generation_complete = generation_complete
 
 
 class FakeResponse:
-    def __init__(self, audio_data=None, tool_call=None, turn_complete=False):
+    def __init__(
+        self,
+        audio_data=None,
+        tool_call=None,
+        turn_complete=False,
+        generation_complete=False,
+    ):
         self.data = audio_data
         self.tool_call = FakeToolCallWrapper(tool_call) if tool_call else None
-        self.server_content = FakeServerContent(audio_data, turn_complete)
+        self.server_content = FakeServerContent(audio_data, turn_complete, generation_complete)
 
 
 def make_fake_session(responses):
-    """指定した responses を順に返す AsyncContextManager モック。"""
+    """指定した responses を順に返す AsyncContextManager モック。
+    receive() は 1 ターン分を yield して終了する SDK の仕様を再現するため、
+    2 回目以降の呼び出しでは空のイテレータを返す（while True ループを終了させる）。
+    """
     session = AsyncMock()
 
+    call_count = 0
+
     async def fake_receive():
+        nonlocal call_count
+        if call_count > 0:
+            return  # 2回目以降は空 → got_response=False → break
+        call_count += 1
         for response in responses:
             yield response
 
@@ -124,6 +141,20 @@ async def test_receive_resets_ai_speak_start_on_turn_complete(manager):
 
 
 @pytest.mark.asyncio
+async def test_receive_treats_generation_complete_as_turn_complete(manager):
+    pcm = b"\x00\x01" * 100
+    responses = [FakeResponse(audio_data=pcm), FakeResponse(generation_complete=True)]
+    fake_session = make_fake_session(responses)
+    manager._session = fake_session
+
+    events = []
+    async for event in manager.receive():
+        events.append(event)
+
+    assert any(event["type"] == "turn_complete" for event in events)
+
+
+@pytest.mark.asyncio
 async def test_receive_handles_tool_call(manager):
     """tool_call を受け取ったら send_tool_response を呼ぶ。"""
     tool_call = FakeToolCall()
@@ -156,7 +187,7 @@ async def test_send_audio_calls_send_realtime_input(manager):
 
 @pytest.mark.asyncio
 async def test_send_audio_flushes_audio_stream_end(manager):
-    """録音バッファ送信後に audio_stream_end=True を送って flush する。"""
+    """録音バッファ送信後に activity_end を送って flush する。"""
     fake_session = make_fake_session([])
     manager._session = fake_session
 
@@ -164,7 +195,7 @@ async def test_send_audio_flushes_audio_stream_end(manager):
 
     assert fake_session.send_realtime_input.await_count == 2
     _, last_kwargs = fake_session.send_realtime_input.await_args_list[-1]
-    assert last_kwargs == {"audio_stream_end": True}
+    assert isinstance(last_kwargs["activity_end"], types.ActivityEnd)
 
 
 @pytest.mark.asyncio
@@ -186,7 +217,21 @@ async def test_flush_input_audio_sends_audio_stream_end(manager):
 
     await manager.flush_input_audio()
 
-    fake_session.send_realtime_input.assert_awaited_once_with(audio_stream_end=True)
+    fake_session.send_realtime_input.assert_awaited_once()
+    _, kwargs = fake_session.send_realtime_input.await_args
+    assert isinstance(kwargs["activity_end"], types.ActivityEnd)
+
+
+@pytest.mark.asyncio
+async def test_start_input_audio_sends_activity_start(manager):
+    fake_session = make_fake_session([])
+    manager._session = fake_session
+
+    await manager.start_input_audio()
+
+    fake_session.send_realtime_input.assert_awaited_once()
+    _, kwargs = fake_session.send_realtime_input.await_args
+    assert isinstance(kwargs["activity_start"], types.ActivityStart)
 
 
 @pytest.mark.asyncio
@@ -208,3 +253,34 @@ async def test_receive_yields_multiple_audio_chunks_in_order(manager):
 
     audio_events = [event for event in events if event["type"] == "audio_chunk"]
     assert len(audio_events) == 2
+
+
+@pytest.mark.asyncio
+async def test_connect_configures_server_side_vad():
+    fake_session = AsyncMock()
+    fake_ctx = AsyncMock()
+    fake_ctx.__aenter__.return_value = fake_session
+
+    fake_client = MagicMock()
+    fake_client.aio.live.connect.return_value = fake_ctx
+
+    manager = LiveSessionManager(client=fake_client)
+
+    await manager.connect()
+
+    _, kwargs = fake_client.aio.live.connect.call_args
+    config = kwargs["config"]
+    realtime_input_config = config.realtime_input_config
+
+    assert realtime_input_config is not None
+    assert (
+        realtime_input_config.activity_handling
+        == types.ActivityHandling.START_OF_ACTIVITY_INTERRUPTS
+    )
+    assert (
+        realtime_input_config.turn_coverage
+        == types.TurnCoverage.TURN_INCLUDES_ONLY_ACTIVITY
+    )
+
+    # automatic_activity_detection は設定しない → Gemini Live API の自動 VAD を有効にする
+    assert realtime_input_config.automatic_activity_detection is None

--- a/backend/tests/test_live_session.py
+++ b/backend/tests/test_live_session.py
@@ -128,4 +128,19 @@ async def test_send_audio_calls_send_realtime_input(manager):
     manager._session = fake_session
     pcm = b"\x00" * 3200
     await manager.send_audio(pcm)
-    fake_session.send_realtime_input.assert_called_once()
+    first_args, first_kwargs = fake_session.send_realtime_input.await_args_list[0]
+    assert not first_args
+    assert first_kwargs["audio"].mime_type == "audio/pcm;rate=16000"
+
+
+@pytest.mark.asyncio
+async def test_send_audio_flushes_audio_stream_end(manager):
+    """録音バッファ送信後に audio_stream_end=True を送って flush する。"""
+    fake_session = make_fake_session([])
+    manager._session = fake_session
+
+    await manager.send_audio(b"\x00" * 3200)
+
+    assert fake_session.send_realtime_input.await_count == 2
+    _, last_kwargs = fake_session.send_realtime_input.await_args_list[-1]
+    assert last_kwargs == {"audio_stream_end": True}

--- a/backend/tests/test_live_session.py
+++ b/backend/tests/test_live_session.py
@@ -1,0 +1,131 @@
+"""LiveSessionManager のユニットテスト（Gemini API はモック）。"""
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from src.live_session import LiveSessionManager
+
+
+class FakeToolCall:
+    def __init__(self):
+        self.id = "call-001"
+        self.name = "get_agitation"
+        self.args = {}
+
+
+class FakeToolCallWrapper:
+    """live_session.py の `for call in response.tool_call.function_calls` に対応。"""
+
+    def __init__(self, call):
+        self.function_calls = [call]
+
+
+class FakeServerContent:
+    def __init__(self, audio_data=None, turn_complete=False):
+        self.parts = [MagicMock(inline_data=MagicMock(data=audio_data))] if audio_data else []
+        self.turn_complete = turn_complete
+
+
+class FakeResponse:
+    def __init__(self, audio_data=None, tool_call=None, turn_complete=False):
+        self.data = audio_data
+        self.tool_call = FakeToolCallWrapper(tool_call) if tool_call else None
+        self.server_content = FakeServerContent(audio_data, turn_complete)
+
+
+def make_fake_session(responses):
+    """指定した responses を順に返す AsyncContextManager モック。"""
+    session = AsyncMock()
+
+    async def fake_receive():
+        for response in responses:
+            yield response
+
+    session.receive = fake_receive
+    session.send_realtime_input = AsyncMock()
+    session.send_tool_response = AsyncMock()
+    return session
+
+
+@pytest.fixture
+def manager():
+    return LiveSessionManager(agitation_api_url="http://localhost:8001")
+
+
+@pytest.mark.asyncio
+async def test_receive_yields_audio_chunk(manager):
+    """audio データが来たら audio_chunk イベントを yield する。"""
+    pcm = b"\x00\x01" * 100
+    responses = [
+        FakeResponse(audio_data=pcm),
+        FakeResponse(turn_complete=True),
+    ]
+    fake_session = make_fake_session(responses)
+    manager._session = fake_session
+
+    events = []
+    async for event in manager.receive():
+        events.append(event)
+
+    assert any(event["type"] == "audio_chunk" for event in events)
+    assert any(event["type"] == "turn_complete" for event in events)
+
+
+@pytest.mark.asyncio
+async def test_receive_sets_ai_speak_start_on_first_audio(manager):
+    """最初の audio chunk 受信時に _ai_speak_start がセットされる。"""
+    pcm = b"\x00\x01" * 100
+    responses = [FakeResponse(audio_data=pcm), FakeResponse(turn_complete=True)]
+    fake_session = make_fake_session(responses)
+    manager._session = fake_session
+    assert manager._ai_speak_start is None
+
+    receive_iter = manager.receive()
+    first_event = await anext(receive_iter)
+
+    assert first_event["type"] == "audio_chunk"
+    assert manager._ai_speak_start is not None
+    await receive_iter.aclose()
+
+
+@pytest.mark.asyncio
+async def test_receive_resets_ai_speak_start_on_turn_complete(manager):
+    """turn_complete 受信後は _ai_speak_start をリセットする。"""
+    pcm = b"\x00\x01" * 100
+    responses = [FakeResponse(audio_data=pcm), FakeResponse(turn_complete=True)]
+    fake_session = make_fake_session(responses)
+    manager._session = fake_session
+
+    async for _ in manager.receive():
+        pass
+
+    assert manager._ai_speak_start is None
+
+
+@pytest.mark.asyncio
+async def test_receive_handles_tool_call(manager):
+    """tool_call を受け取ったら send_tool_response を呼ぶ。"""
+    tool_call = FakeToolCall()
+    responses = [
+        FakeResponse(tool_call=tool_call),
+        FakeResponse(turn_complete=True),
+    ]
+    fake_session = make_fake_session(responses)
+    manager._session = fake_session
+
+    with patch.object(manager, "_fetch_agitation_window", new_callable=AsyncMock) as mock_fetch:
+        mock_fetch.return_value = {"level": 42, "peak": 42, "trend": "rising"}
+        async for _ in manager.receive():
+            pass
+
+    fake_session.send_tool_response.assert_called_once()
+
+
+@pytest.mark.asyncio
+async def test_send_audio_calls_send_realtime_input(manager):
+    """send_audio() は send_realtime_input() を呼ぶ。"""
+    fake_session = make_fake_session([])
+    manager._session = fake_session
+    pcm = b"\x00" * 3200
+    await manager.send_audio(pcm)
+    fake_session.send_realtime_input.assert_called_once()

--- a/backend/tests/test_live_session.py
+++ b/backend/tests/test_live_session.py
@@ -165,3 +165,25 @@ async def test_send_audio_flushes_audio_stream_end(manager):
     assert fake_session.send_realtime_input.await_count == 2
     _, last_kwargs = fake_session.send_realtime_input.await_args_list[-1]
     assert last_kwargs == {"audio_stream_end": True}
+
+
+@pytest.mark.asyncio
+async def test_send_audio_chunk_sends_single_pcm_chunk(manager):
+    fake_session = make_fake_session([])
+    manager._session = fake_session
+
+    await manager.send_audio_chunk(b"\x01\x02" * 100)
+
+    fake_session.send_realtime_input.assert_awaited_once()
+    _, kwargs = fake_session.send_realtime_input.await_args
+    assert kwargs["audio"].mime_type == "audio/pcm;rate=16000"
+
+
+@pytest.mark.asyncio
+async def test_flush_input_audio_sends_audio_stream_end(manager):
+    fake_session = make_fake_session([])
+    manager._session = fake_session
+
+    await manager.flush_input_audio()
+
+    fake_session.send_realtime_input.assert_awaited_once_with(audio_stream_end=True)

--- a/backend/tests/test_live_session.py
+++ b/backend/tests/test_live_session.py
@@ -187,3 +187,24 @@ async def test_flush_input_audio_sends_audio_stream_end(manager):
     await manager.flush_input_audio()
 
     fake_session.send_realtime_input.assert_awaited_once_with(audio_stream_end=True)
+
+
+@pytest.mark.asyncio
+async def test_receive_yields_multiple_audio_chunks_in_order(manager):
+    pcm1 = b"\x00\x01" * 10
+    pcm2 = b"\x02\x03" * 10
+    fake_session = make_fake_session(
+        [
+            FakeResponse(audio_data=pcm1),
+            FakeResponse(audio_data=pcm2),
+            FakeResponse(turn_complete=True),
+        ]
+    )
+    manager._session = fake_session
+
+    events = []
+    async for event in manager.receive():
+        events.append(event)
+
+    audio_events = [event for event in events if event["type"] == "audio_chunk"]
+    assert len(audio_events) == 2

--- a/backend/tests/test_main.py
+++ b/backend/tests/test_main.py
@@ -31,3 +31,15 @@ def test_ws_session_sends_ready_event(mock_manager):
 
     assert message["type"] == "session_ready"
     mock_manager.connect.assert_awaited_once()
+
+
+def test_ws_binary_audio_calls_send_audio_chunk(mock_manager):
+    with patch("src.main.LiveSessionManager", return_value=mock_manager):
+        from src.main import app
+
+        client = TestClient(app)
+        with client.websocket_connect("/ws/session") as ws:
+            ws.receive_json()
+            ws.send_bytes(b"\x00\x01" * 100)
+
+    mock_manager.send_audio_chunk.assert_awaited()

--- a/backend/tests/test_main.py
+++ b/backend/tests/test_main.py
@@ -1,0 +1,92 @@
+"""main.py エンドポイントの統合テスト。LiveSessionManager はモック。"""
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from httpx import ASGITransport, AsyncClient
+
+
+@pytest.fixture
+def mock_manager():
+    manager = MagicMock()
+    manager.connect = AsyncMock()
+    manager.disconnect = AsyncMock()
+    manager.send_audio = AsyncMock()
+
+    async def fake_receive():
+        yield {"type": "audio_chunk", "data": "AAEC"}
+        yield {"type": "turn_complete"}
+
+    manager.receive = fake_receive
+    return manager
+
+
+@pytest.mark.asyncio
+async def test_session_start_returns_session_id(mock_manager):
+    with patch("src.main.LiveSessionManager", return_value=mock_manager):
+        from src.main import app
+
+        async with AsyncClient(
+            transport=ASGITransport(app=app),
+            base_url="http://test",
+        ) as client:
+            response = await client.post("/api/session/start")
+
+    assert response.status_code == 200
+    assert "session_id" in response.json()
+
+
+@pytest.mark.asyncio
+async def test_audio_returns_sse(mock_manager):
+    with patch("src.main.LiveSessionManager", return_value=mock_manager):
+        from src.main import app, sessions
+
+        session_id = "test-session-123"
+        sessions[session_id] = mock_manager
+
+        async with AsyncClient(
+            transport=ASGITransport(app=app),
+            base_url="http://test",
+        ) as client:
+            response = await client.post(
+                f"/api/audio?session_id={session_id}",
+                content=b"\x00" * 3200,
+                headers={"Content-Type": "audio/octet-stream"},
+            )
+
+    assert response.status_code == 200
+    assert "text/event-stream" in response.headers["content-type"]
+
+
+@pytest.mark.asyncio
+async def test_audio_unknown_session_returns_404(mock_manager):
+    with patch("src.main.LiveSessionManager", return_value=mock_manager):
+        from src.main import app
+
+        async with AsyncClient(
+            transport=ASGITransport(app=app),
+            base_url="http://test",
+        ) as client:
+            response = await client.post(
+                "/api/audio?session_id=does-not-exist",
+                content=b"\x00" * 3200,
+            )
+
+    assert response.status_code == 404
+
+
+@pytest.mark.asyncio
+async def test_session_delete(mock_manager):
+    with patch("src.main.LiveSessionManager", return_value=mock_manager):
+        from src.main import app, sessions
+
+        session_id = "del-session-456"
+        sessions[session_id] = mock_manager
+
+        async with AsyncClient(
+            transport=ASGITransport(app=app),
+            base_url="http://test",
+        ) as client:
+            response = await client.delete(f"/api/session?session_id={session_id}")
+
+    assert response.status_code == 200
+    assert session_id not in sessions

--- a/backend/tests/test_main.py
+++ b/backend/tests/test_main.py
@@ -10,6 +10,7 @@ def mock_manager():
     manager = MagicMock()
     manager.connect = AsyncMock()
     manager.disconnect = AsyncMock()
+    manager.start_input_audio = AsyncMock()
     manager.send_audio_chunk = AsyncMock()
     manager.flush_input_audio = AsyncMock()
 
@@ -72,3 +73,16 @@ def test_ws_input_audio_end_calls_flush(mock_manager):
             ws.send_json({"type": "input_audio_end"})
 
     mock_manager.flush_input_audio.assert_awaited()
+
+
+def test_ws_input_audio_start_is_ignored(mock_manager):
+    """input_audio_start は Live VAD 主導設計では無視される。"""
+    with patch("src.main.LiveSessionManager", return_value=mock_manager):
+        from src.main import app
+
+        client = TestClient(app)
+        with client.websocket_connect("/ws/session") as ws:
+            ws.receive_json()
+            ws.send_json({"type": "input_audio_start"})
+
+    mock_manager.start_input_audio.assert_not_awaited()

--- a/backend/tests/test_main.py
+++ b/backend/tests/test_main.py
@@ -1,8 +1,8 @@
-"""main.py エンドポイントの統合テスト。LiveSessionManager はモック。"""
+"""main.py WebSocket エンドポイントの統合テスト。LiveSessionManager はモック。"""
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
-from httpx import ASGITransport, AsyncClient
+from fastapi.testclient import TestClient
 
 
 @pytest.fixture
@@ -10,83 +10,24 @@ def mock_manager():
     manager = MagicMock()
     manager.connect = AsyncMock()
     manager.disconnect = AsyncMock()
-    manager.send_audio = AsyncMock()
+    manager.send_audio_chunk = AsyncMock()
+    manager.flush_input_audio = AsyncMock()
 
     async def fake_receive():
-        yield {"type": "audio_chunk", "data": "AAEC"}
-        yield {"type": "turn_complete"}
+        if False:
+            yield {}
 
     manager.receive = fake_receive
     return manager
 
 
-@pytest.mark.asyncio
-async def test_session_start_returns_session_id(mock_manager):
+def test_ws_session_sends_ready_event(mock_manager):
     with patch("src.main.LiveSessionManager", return_value=mock_manager):
         from src.main import app
 
-        async with AsyncClient(
-            transport=ASGITransport(app=app),
-            base_url="http://test",
-        ) as client:
-            response = await client.post("/api/session/start")
+        client = TestClient(app)
+        with client.websocket_connect("/ws/session") as ws:
+            message = ws.receive_json()
 
-    assert response.status_code == 200
-    assert "session_id" in response.json()
-
-
-@pytest.mark.asyncio
-async def test_audio_returns_sse(mock_manager):
-    with patch("src.main.LiveSessionManager", return_value=mock_manager):
-        from src.main import app, sessions
-
-        session_id = "test-session-123"
-        sessions[session_id] = mock_manager
-
-        async with AsyncClient(
-            transport=ASGITransport(app=app),
-            base_url="http://test",
-        ) as client:
-            response = await client.post(
-                f"/api/audio?session_id={session_id}",
-                content=b"\x00" * 3200,
-                headers={"Content-Type": "audio/octet-stream"},
-            )
-
-    assert response.status_code == 200
-    assert "text/event-stream" in response.headers["content-type"]
-
-
-@pytest.mark.asyncio
-async def test_audio_unknown_session_returns_404(mock_manager):
-    with patch("src.main.LiveSessionManager", return_value=mock_manager):
-        from src.main import app
-
-        async with AsyncClient(
-            transport=ASGITransport(app=app),
-            base_url="http://test",
-        ) as client:
-            response = await client.post(
-                "/api/audio?session_id=does-not-exist",
-                content=b"\x00" * 3200,
-            )
-
-    assert response.status_code == 404
-
-
-@pytest.mark.asyncio
-async def test_session_delete(mock_manager):
-    with patch("src.main.LiveSessionManager", return_value=mock_manager):
-        from src.main import app, sessions
-
-        session_id = "del-session-456"
-        sessions[session_id] = mock_manager
-
-        async with AsyncClient(
-            transport=ASGITransport(app=app),
-            base_url="http://test",
-        ) as client:
-            response = await client.delete(f"/api/session?session_id={session_id}")
-
-    assert response.status_code == 200
-    assert session_id not in sessions
+    assert message["type"] == "session_ready"
+    mock_manager.connect.assert_awaited_once()

--- a/backend/tests/test_main.py
+++ b/backend/tests/test_main.py
@@ -43,3 +43,20 @@ def test_ws_binary_audio_calls_send_audio_chunk(mock_manager):
             ws.send_bytes(b"\x00\x01" * 100)
 
     mock_manager.send_audio_chunk.assert_awaited()
+
+
+def test_ws_forwards_audio_chunk_and_turn_complete(mock_manager):
+    async def fake_receive():
+        yield {"type": "audio_chunk", "data": "AAEC"}
+        yield {"type": "turn_complete"}
+
+    mock_manager.receive = fake_receive
+
+    with patch("src.main.LiveSessionManager", return_value=mock_manager):
+        from src.main import app
+
+        client = TestClient(app)
+        with client.websocket_connect("/ws/session") as ws:
+            assert ws.receive_json()["type"] == "session_ready"
+            assert ws.receive_json()["type"] == "audio_chunk"
+            assert ws.receive_json()["type"] == "turn_complete"

--- a/backend/tests/test_main.py
+++ b/backend/tests/test_main.py
@@ -60,3 +60,15 @@ def test_ws_forwards_audio_chunk_and_turn_complete(mock_manager):
             assert ws.receive_json()["type"] == "session_ready"
             assert ws.receive_json()["type"] == "audio_chunk"
             assert ws.receive_json()["type"] == "turn_complete"
+
+
+def test_ws_input_audio_end_calls_flush(mock_manager):
+    with patch("src.main.LiveSessionManager", return_value=mock_manager):
+        from src.main import app
+
+        client = TestClient(app)
+        with client.websocket_connect("/ws/session") as ws:
+            ws.receive_json()
+            ws.send_json({"type": "input_audio_end"})
+
+    mock_manager.flush_input_audio.assert_awaited()

--- a/docs/plans/2026-03-15-live-api-websocket-design.md
+++ b/docs/plans/2026-03-15-live-api-websocket-design.md
@@ -1,0 +1,166 @@
+# PalmPalm Live API WebSocket Design
+
+## Goal
+
+Gemini Live API セッションを常時維持しつつ、ブラウザのマイクPCMをリアルタイムにストリーミングして、無音で AI ターン開始・割り込み発話・tool use による動揺度取得を自然に行える構成へ移行する。
+
+## Scope
+
+- ブラウザとバックエンド間を `POST /api/audio + SSE` から `WebSocket` へ移行する
+- バックエンドと Gemini Live API の接続はセッション単位で持続させる
+- `get_agitation` tool は当面「直近 N 秒のローリング集計」を返す
+- 将来、「AI が話し始めてから tool call 時点まで」の統計へ差し替えやすい形を保つ
+
+## Non-Goals
+
+- 動揺度の意味づけやプロンプト最適化
+- UI の残り秒数表示の整理
+- テキスト字幕の復活
+- センサー側 API の大きな仕様変更
+
+## Approach
+
+### Recommended Architecture
+
+1. ブラウザは `AudioWorklet` で 16kHz mono int16 PCM を小さいチャンクで継続送信する
+2. バックエンドは `WebSocket /ws/session` でクライアント接続を受け、1 接続につき 1 つの `LiveSessionManager` を持つ
+3. `LiveSessionManager` は Gemini Live API へ音声チャンクを順次送信し、返ってきた音声チャンクを即座にフロントへ返す
+4. Gemini の自動 VAD を基本とし、将来の安定化のため `input_audio_end` メッセージを残す
+5. `get_agitation` はバックエンドで処理し、AI が任意のタイミングで呼び出せるようにする
+
+### Alternatives Considered
+
+- `POST /api/audio + SSE` を細切れ送信へ拡張
+  - 既存コードは一部使えるが、割り込みとターン制御が不自然で捨て実装になりやすい
+- ブラウザから Gemini Live API へ直接接続
+  - API キー管理と tool use 実装が煩雑になり、このプロジェクトには不向き
+
+## Protocol
+
+### Client → Server
+
+- Binary frame
+  - PCM 16kHz mono int16 の音声チャンク
+- Text frame: `{"type":"input_audio_end"}`
+  - 明示 flush 用
+- Text frame: `{"type":"session_end"}`
+  - セッション終了
+
+### Server → Client
+
+- Text frame: `{"type":"session_ready"}`
+  - Live API セッション確立完了
+- Text frame: `{"type":"audio_chunk","data":"<base64 PCM 24kHz>"}`
+  - Gemini からの音声
+- Text frame: `{"type":"turn_complete"}`
+  - AI 発話終了
+- Text frame: `{"type":"error","message":"..."}`
+  - 切断や API 異常
+
+## Backend Design
+
+### `backend/src/main.py`
+
+- `POST /api/session/start`
+- `POST /api/audio`
+- `DELETE /api/session`
+
+上記のセッション API は不要になる。代わりに `WebSocket /ws/session` を追加する。
+
+責務:
+- 接続時に `LiveSessionManager.connect()`
+- クライアントからの binary frame を `send_audio_chunk()` に渡す
+- Gemini 側イベントをクライアントへそのまま転送する
+- 切断時に `disconnect()` を保証する
+
+### `backend/src/live_session.py`
+
+責務:
+- 常駐 Live API セッションの確立と切断
+- 音声チャンクの逐次送信
+- `input_audio_end` 時の flush
+- Gemini 受信イベントから音声データを抽出
+- `get_agitation` tool call への応答
+
+変更点:
+- まとめ送信前提の `send_audio()` を `send_audio_chunk()` と `flush_input_audio()` に分ける
+- `receive()` は async generator として維持し、WebSocket 層から中継しやすくする
+- 音声抽出は `response.data` と `response.server_content.model_turn.parts[].inline_data` の両方を扱う
+
+### `backend/src/agitation_engine.py`
+
+当面は `snapshot_window()` を流用するか、より単純に `snapshot()` を使う。
+初期リリースでは「実装容易性」を優先し、tool call 時点から見た直近 N 秒の集計で十分とする。
+
+## Frontend Design
+
+### `frontend/src/hooks/useSession.js`
+
+責務:
+- `WebSocket` 接続をセッション中 1 本維持
+- `AudioWorklet` の PCM バッファを binary frame で逐次送信
+- サーバーから来た `audio_chunk` を `Web Audio API` で再生
+- `session_ready` を受けるまで送信しない
+- `turn_complete` でユーザーターンへ戻す
+
+変更点:
+- `fetch + SSE` を廃止
+- `sessionId` 管理は不要
+- `turn` は `user` / `ai` のままで十分
+- 録音タイマーは UI 表示とは切り離し、必要なら内部制御だけ残す
+
+### `frontend/public/pcm-processor.js`
+
+既存の実装を継続利用する。責務は PCM 変換のみで変更しない。
+
+## Tool Use
+
+- モデルは `get_agitation` を任意のタイミングで呼べる
+- バックエンドは HTTP 経由またはローカル計算で値を返す
+- 初期版の返却値:
+  - `level`
+  - `peak`
+  - `trend`
+- 後続で「AI 発話開始から tool call 時点まで」の統計に変更しても、tool 名とレスポンス形は維持する
+
+## Error Handling
+
+- WebSocket 接続失敗時は `vadError` に反映
+- Live API 異常時は `error` イベントをフロントへ送る
+- セッション切断時は録音・再生・AudioContext を確実に解放する
+- `session_ready` 前に送られた音声は破棄するか送信開始を待つ
+
+## Testing Strategy
+
+### Backend
+
+- `test_live_session.py`
+  - `send_audio_chunk()` が chunk をそのまま送る
+  - `flush_input_audio()` が `audio_stream_end=True` を送る
+  - `receive()` が `model_turn.parts.inline_data` から音声を返す
+  - tool call 応答が継続する
+- `test_main.py`
+  - `WebSocket /ws/session` 接続成功
+  - binary frame 受信で `send_audio_chunk()` が呼ばれる
+  - `session_ready` / `audio_chunk` / `turn_complete` が転送される
+  - 切断時に `disconnect()` が呼ばれる
+
+### Frontend
+
+- `npm run build`
+- Chrome 手動確認
+  - マイク許可
+  - 接続成功
+  - 無音後に AI 音声が始まる
+  - AI 発話中の割り込み
+
+## Risks
+
+- ブラウザと Gemini の VAD の境界が競合する可能性
+- binary frame と text frame の混在処理で実装ミスが起きやすい
+- 接続断時の AudioContext 解放漏れ
+
+## Rollout Notes
+
+- 先に WebSocket 経路を通し、動揺度は簡易ローリング集計で固定する
+- その後、動揺度の統計区間を「AI 発話開始から」に変更する設計を別途行う

--- a/docs/plans/2026-03-15-live-vad-websocket-design.md
+++ b/docs/plans/2026-03-15-live-vad-websocket-design.md
@@ -1,0 +1,146 @@
+# PalmPalm Live VAD WebSocket Design
+
+## Goal
+
+Gemini Live API の自動 VAD を主導にして、ブラウザからの常時音声ストリーミング、自然なターン切替、割り込み、tool use による動揺度取得を安定させる。あわせて、2ターン目以降に音声が返らない不具合を調査できる観測点を加える。
+
+## Why Change
+
+現状は以下の二重管理になっている。
+
+- Gemini Live API 側の自動 VAD
+- フロントエンド側の 10 秒タイマーと silence 判定
+
+この構成では以下の問題が起きやすい。
+
+- ターン切替の責務が二重化する
+- 無音入力時にフロントが先に状態遷移して固まりやすい
+- `input_audio_end` の重複送信が起きやすい
+- 2ターン目以降に WebSocket や Live API セッションの状態が崩れた時に観測しづらい
+
+## Design Choice
+
+### Recommended
+
+Live VAD 主導に寄せる。
+
+- PCM は WebSocket で常時送信
+- クライアントは silence 判定しない
+- ターンの終了は Gemini Live API の `turn_complete` を基準にする
+- `input_audio_end` は原則送らない
+- UI の 10 秒カウントダウンは撤去する
+
+### Rejected
+
+- クライアント側 VAD を調整し続ける
+  - Live VAD と競合し続ける
+- HTTP/SSE に戻す
+  - 目的である常時接続と割り込みに逆行する
+
+## Target Behavior
+
+### Session Lifecycle
+
+- セッション開始時に `WebSocket /ws/session` を 1 本確立する
+- バックエンドは 1 接続ごとに `LiveSessionManager` を 1 本維持する
+- ページ離脱または終了時に `session_end` を送り、WebSocket を閉じる
+
+### Audio Input
+
+- ブラウザは `AudioWorklet` で 16kHz mono int16 PCM を生成する
+- PCM chunk は常時 WebSocket binary frame で送る
+- 無音でも turn を強制終了しない
+- 長時間無音に対してもクライアント側で `ai` ターンへ遷移しない
+
+### AI Turn
+
+- Gemini Live API が自動 VAD で入力区切りを判断する
+- `audio_chunk` を受けた時点で UI は `ai` ターンへ入る
+- `turn_complete` を受けたら UI は `user` ターンへ戻る
+- 割り込みは常時送信を続けることで Live API に委ねる
+
+### Tool Use
+
+- `get_agitation` は引き続きバックエンド実装で処理する
+- 当面はローリング集計を返す
+- 後で「AI発話開始から tool call 時点まで」の集計へ差し替える
+
+## Debugging Instrumentation
+
+2ターン目以降の不具合を切り分けるため、最小限のログを入れる。
+
+### Backend `live_session.py`
+
+- `send_audio_chunk()` 呼び出し回数
+- `receive()` 内の
+  - `audio_chunk` 送出回数
+  - `tool_call` 回数
+  - `turn_complete` 検知
+- `disconnect()` 時刻
+
+### Backend `main.py`
+
+- WebSocket accept / close
+- close の理由
+- binary frame 受信回数
+- 例外発生時の stack trace
+
+### Frontend `useSession.js`
+
+- socket open / close / error
+- `audio_chunk` 受信回数
+- `turn_complete` 受信回数
+- `turn` の遷移
+
+## Frontend Changes
+
+### `frontend/src/hooks/useSession.js`
+
+- `MAX_RECORD_SECONDS` と `timeLeft` を削除
+- silence 判定を削除
+- `input_audio_end` 送信を通常フローから削除
+- `turn_complete` だけで `user` ターンへ戻す
+- デバッグログを追加
+
+### `frontend/src/pages/SessionPage.jsx`
+
+- 録音カウントダウン表示を削除
+- 必要ならセッション全体制限表示も削除候補
+- ただし見た目の整理は二次的で、まずターン制御から切り離す
+
+## Backend Changes
+
+### `backend/src/main.py`
+
+- WebSocket text frame は `session_end` のみ残す
+- `input_audio_end` への依存を外す
+- 調査ログを追加
+
+### `backend/src/live_session.py`
+
+- `flush_input_audio()` は残してよいが通常フローでは使わない
+- `send_audio_chunk()` を主経路にする
+- 調査ログを追加
+
+## Verification
+
+### Automated
+
+- `uv run pytest tests/ -v`
+- `npm run build`
+
+### Manual
+
+Chrome で以下を確認する。
+
+1. `ws://127.0.0.1:8000/ws/session` が接続維持される
+2. 1ターン目の応答が再生される
+3. 2ターン目以降も再生される
+4. 無音時に UI が固まらず、`user` ターンのまま待つ
+5. AI 発話中にユーザーが話し始めると割り込める
+
+## Risks
+
+- 常時送信による不要な無音 chunk が多いと、Live API 側の挙動が読みにくい
+- turn 切替を完全に Live VAD 任せにすると、UI 応答性に調整が必要になる場合がある
+- ログを増やしすぎると追いづらくなるので最小限に留める

--- a/docs/plans/2026-03-15-live-vad-websocket.md
+++ b/docs/plans/2026-03-15-live-vad-websocket.md
@@ -1,0 +1,248 @@
+# Live VAD WebSocket Stabilization Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Gemini Live API の自動 VAD を主導にして、2ターン目以降も安定して音声応答が返る WebSocket ストリーミングに整理する。
+
+**Architecture:** ブラウザは PCM chunk を常時 WebSocket 送信し、ターン切替は Gemini Live API の `turn_complete` を基準にする。クライアント側の silence 判定と 10 秒タイマーは廃止し、バックエンドとフロントの両方に最小限の観測ログを加えて 2ターン目以降の不具合を切り分ける。
+
+**Tech Stack:** Python 3.11 / FastAPI WebSocket / google-genai Live API / pytest / React / WebSocket / Web Audio API / AudioWorklet
+
+---
+
+## Chunk 1: 観測点を追加する
+
+### Task 1: `live_session.py` に送受信ログを追加する
+
+**Files:**
+- Modify: `backend/src/live_session.py`
+
+- [ ] **Step 1: 最小ログを追加**
+
+以下を `print(..., flush=True)` で追加する。
+
+- `send_audio_chunk()` 呼び出し時
+- `receive()` で `audio_chunk` を yield する時
+- `receive()` で `tool_call` を処理する時
+- `receive()` で `turn_complete` を yield する時
+- `disconnect()` 実行時
+
+ログには event 種別と簡単なカウントまたは時刻を入れる。
+
+- [ ] **Step 2: テストを実行**
+
+```bash
+cd backend && uv run pytest tests/test_live_session.py -v
+```
+
+Expected: 全テスト PASSED
+
+- [ ] **Step 3: コミット**
+
+```bash
+git add backend/src/live_session.py
+git commit -m "chore: add live session debug logging"
+```
+
+---
+
+### Task 2: `main.py` に WebSocket 接続理由ログを追加する
+
+**Files:**
+- Modify: `backend/src/main.py`
+
+- [ ] **Step 1: 最小ログを追加**
+
+以下を追加する。
+
+- WebSocket accept 時
+- binary frame 受信時
+- text frame 受信時
+- `WebSocketDisconnect` 捕捉時
+- 例外時の stack trace
+- finally 節で close 時
+
+- [ ] **Step 2: テストを実行**
+
+```bash
+cd backend && uv run pytest tests/test_main.py -v
+```
+
+Expected: 全テスト PASSED
+
+- [ ] **Step 3: コミット**
+
+```bash
+git add backend/src/main.py
+git commit -m "chore: add websocket session debug logging"
+```
+
+---
+
+## Chunk 2: Live VAD 主導へ切り替える
+
+### Task 3: `useSession.js` から client 側 silence 判定を削除する
+
+**Files:**
+- Modify: `frontend/src/hooks/useSession.js`
+
+- [ ] **Step 1: 実装を簡素化**
+
+以下を削除する。
+
+- `SILENCE_THRESHOLD`
+- `SILENCE_MS`
+- `silenceTimerRef`
+- `speechActiveRef`
+- RMS 計算
+- 無音で `setTurn('ai')` する処理
+- `input_audio_end` 自動送信
+
+`worklet.port.onmessage` は session ready かつ `turn === 'user'` なら PCM binary frame をそのまま送るだけにする。
+
+- [ ] **Step 2: ビルド確認**
+
+```bash
+cd frontend && npm run build
+```
+
+Expected: 成功
+
+- [ ] **Step 3: コミット**
+
+```bash
+git add frontend/src/hooks/useSession.js
+git commit -m "refactor: remove client-side silence detection for live vad"
+```
+
+---
+
+### Task 4: 10 秒タイマー依存を取り除く
+
+**Files:**
+- Modify: `frontend/src/hooks/useSession.js`
+- Modify: `frontend/src/pages/SessionPage.jsx`
+- Modify: `frontend/src/App.jsx`
+
+- [ ] **Step 1: `useSession.js` から録音タイマー state を外す**
+
+- `MAX_RECORD_SECONDS`
+- `timeLeft`
+- `countdownRef`
+- `stopTimerRef`
+
+を削除し、返り値は `{ turn, vadError }` にする。
+
+- [ ] **Step 2: `SessionPage.jsx` と `App.jsx` の props を整理**
+
+- `timeLeft` prop を削除
+- 録音カウントダウン表示を削除
+
+セッション全体の残り時間表示もこの時点で不要なら削除してよい。
+
+- [ ] **Step 3: ビルド確認**
+
+```bash
+cd frontend && npm run build
+```
+
+Expected: 成功
+
+- [ ] **Step 4: コミット**
+
+```bash
+git add frontend/src/hooks/useSession.js frontend/src/pages/SessionPage.jsx frontend/src/App.jsx
+git commit -m "refactor: remove countdown-based turn control"
+```
+
+---
+
+### Task 5: `main.py` の `input_audio_end` 依存を弱める
+
+**Files:**
+- Modify: `backend/src/main.py`
+
+- [ ] **Step 1: `input_audio_end` を通常フローから外す**
+
+`input_audio_end` を受けた時だけ `flush_input_audio()` を呼ぶ挙動は残してよいが、通常は binary frame の常時送信だけで会話が成立する前提にする。
+
+コード上は以下を確認する。
+
+- binary frame が主経路
+- `session_end` は close 用
+- `input_audio_end` は補助経路
+
+- [ ] **Step 2: テストを実行**
+
+```bash
+cd backend && uv run pytest tests/test_main.py -v
+```
+
+Expected: 全テスト PASSED
+
+- [ ] **Step 3: コミット**
+
+```bash
+git add backend/src/main.py
+git commit -m "refactor: make websocket audio streaming primary path"
+```
+
+---
+
+## Chunk 3: 実機確認
+
+### Task 6: ブラウザで 2ターン目以降の再生を確認する
+
+**Files:**
+- Modify: 必要なら `frontend/src/hooks/useSession.js`
+- Modify: 必要なら `backend/src/main.py`
+- Modify: 必要なら `backend/src/live_session.py`
+
+- [ ] **Step 1: バックエンド起動**
+
+```bash
+cd backend && uv run uvicorn src.main:app --host 127.0.0.1 --port 8000
+```
+
+- [ ] **Step 2: フロントエンド起動**
+
+```bash
+cd frontend && VITE_BACKEND_URL=http://127.0.0.1:8000 npm run dev -- --host 127.0.0.1 --port 5173
+```
+
+- [ ] **Step 3: Chrome で確認**
+
+1. `http://127.0.0.1:5173` を開く
+2. 1ターン目の音声再生を確認
+3. 2ターン目の音声再生を確認
+4. 無音時に固まらず `user` ターンのまま待機することを確認
+5. AI 発話中に割り込めるか確認
+
+- [ ] **Step 4: ログを確認**
+
+バックエンドログから以下を確認する。
+
+- 2ターン目でも binary frame を受けているか
+- `audio_chunk` が返っているか
+- `turn_complete` が返っているか
+- close がどのタイミングで起きているか
+
+- [ ] **Step 5: 必要なら最小修正**
+
+ログから根因が出た場合のみ、最小修正を入れて再確認する。
+
+- [ ] **Step 6: 全テスト**
+
+```bash
+cd backend && uv run pytest tests/ -v
+cd ../frontend && npm run build
+```
+
+Expected: どちらも成功
+
+- [ ] **Step 7: コミット**
+
+```bash
+git add -A
+git commit -m "fix: stabilize websocket live vad turn handling"
+```

--- a/docs/superpowers/plans/2026-03-14-live-api-latency.md
+++ b/docs/superpowers/plans/2026-03-14-live-api-latency.md
@@ -1,0 +1,1226 @@
+# Live API レイテンシ改善 Implementation Plan
+
+> **For agentic workers:** REQUIRED: Use superpowers:subagent-driven-development (if subagents available) or superpowers:executing-plans to implement this plan. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Gemini Live API + Tool Use への移行により、stage1 first audio を ~15s → ~2s に短縮し、2段階の gap を廃止する。
+
+**Architecture:** Gemini Live API WebSocket セッションを占いセッション全体で持続させ、agitation データは `get_agitation` tool として AI が自律的に呼び出す。AgitationEngine にタイムウィンドウクエリを追加し、AI が発話し始めた時刻から tool call 時点までの振動データを返す。
+
+**Tech Stack:** Python 3.11 / FastAPI / google-genai (Live API) / pytest / React / Web Audio API / AudioWorklet
+
+---
+
+## Chunk 1: AgitationEngine + AgitationServer 拡張
+
+### Task 1: AgitationEngine に `_calc_trend` を切り出し
+
+**Files:**
+- Modify: `backend/src/agitation_engine.py`
+- Test: `backend/tests/test_agitation_engine.py`
+
+- [ ] **Step 1: 失敗するテストを書く**
+
+`backend/tests/test_agitation_engine.py` の末尾に追加：
+
+```python
+def test_calc_trend_rising():
+    """_calc_trend: diff > 10 で rising"""
+    engine = AgitationEngine(window_seconds=10, max_pulses=20)
+    engine._previous_level = 30
+    assert engine._calc_trend(50) == "rising"
+
+
+def test_calc_trend_falling():
+    """_calc_trend: diff < -10 で falling"""
+    engine = AgitationEngine(window_seconds=10, max_pulses=20)
+    engine._previous_level = 60
+    assert engine._calc_trend(40) == "falling"
+
+
+def test_calc_trend_stable():
+    """_calc_trend: diff が ±10 以内で stable"""
+    engine = AgitationEngine(window_seconds=10, max_pulses=20)
+    engine._previous_level = 50
+    assert engine._calc_trend(55) == "stable"
+```
+
+- [ ] **Step 2: テストが失敗することを確認**
+
+```bash
+cd backend && uv run pytest tests/test_agitation_engine.py::test_calc_trend_rising -v
+```
+
+Expected: `FAILED` / `AttributeError: 'AgitationEngine' object has no attribute '_calc_trend'`
+
+- [ ] **Step 3: `_calc_trend` を実装**
+
+`backend/src/agitation_engine.py` の `trend` プロパティの直前に追加し、`trend` プロパティは `_calc_trend` を使うよう変更：
+
+```python
+def _calc_trend(self, level: int) -> str:
+    diff = level - self._previous_level
+    if diff > 10:
+        return "rising"
+    elif diff < -10:
+        return "falling"
+    return "stable"
+
+@property
+def trend(self) -> str:
+    return self._calc_trend(self.level)
+```
+
+- [ ] **Step 4: 全テストが通ることを確認**
+
+```bash
+cd backend && uv run pytest tests/test_agitation_engine.py -v
+```
+
+Expected: 全テスト PASSED
+
+- [ ] **Step 5: コミット**
+
+```bash
+git add backend/src/agitation_engine.py backend/tests/test_agitation_engine.py
+git commit -m "refactor: extract _calc_trend from trend property"
+```
+
+---
+
+### Task 2: AgitationEngine に `snapshot_window` を追加
+
+**Files:**
+- Modify: `backend/src/agitation_engine.py`
+- Test: `backend/tests/test_agitation_engine.py`
+
+- [ ] **Step 1: 失敗するテストを書く**
+
+`backend/tests/test_agitation_engine.py` の末尾に追加：
+
+```python
+def test_snapshot_window_counts_pulses_in_range():
+    """指定期間内のパルスのみ集計する"""
+    import time
+    engine = AgitationEngine(window_seconds=60, max_pulses=10)
+    before = time.time()
+    for _ in range(5):
+        engine.record_pulse()
+    after = time.time()
+    result = engine.snapshot_window(before, after)
+    assert result["level"] == 50
+    assert result["peak"] == 50
+    assert result["trend"] in ("rising", "falling", "stable")
+
+
+def test_snapshot_window_excludes_out_of_range():
+    """ウィンドウ外のパルスは含まない"""
+    import time
+    engine = AgitationEngine(window_seconds=60, max_pulses=10)
+    for _ in range(5):
+        engine.record_pulse()
+    # ウィンドウを未来に設定（パルスはすべて window 外）
+    future = time.time() + 1000
+    result = engine.snapshot_window(future, future + 1)
+    assert result["level"] == 0
+
+
+def test_snapshot_window_does_not_update_previous_level():
+    """snapshot_window は _previous_level を更新しない"""
+    import time
+    engine = AgitationEngine(window_seconds=60, max_pulses=10)
+    engine._previous_level = 42.0
+    t = time.time()
+    for _ in range(5):
+        engine.record_pulse()
+    engine.snapshot_window(t, time.time())
+    assert engine._previous_level == 42.0
+```
+
+- [ ] **Step 2: テストが失敗することを確認**
+
+```bash
+cd backend && uv run pytest tests/test_agitation_engine.py::test_snapshot_window_counts_pulses_in_range -v
+```
+
+Expected: `FAILED` / `AttributeError: ... no attribute 'snapshot_window'`
+
+- [ ] **Step 3: `snapshot_window` を実装**
+
+`backend/src/agitation_engine.py` に追加（`snapshot` メソッドの下）：
+
+```python
+def snapshot_window(self, from_ts: float, to_ts: float) -> dict:
+    """指定期間内のパルスから level/peak/trend を算出。_previous_level は更新しない。"""
+    pulses_in_window = [t for t in self._pulses if from_ts <= t <= to_ts]
+    level = min(100, int(len(pulses_in_window) / self.max_pulses * 100))
+    return {"level": level, "peak": level, "trend": self._calc_trend(level)}
+```
+
+- [ ] **Step 4: 全テストが通ることを確認**
+
+```bash
+cd backend && uv run pytest tests/test_agitation_engine.py -v
+```
+
+Expected: 全テスト PASSED
+
+- [ ] **Step 5: コミット**
+
+```bash
+git add backend/src/agitation_engine.py backend/tests/test_agitation_engine.py
+git commit -m "feat: add snapshot_window to AgitationEngine"
+```
+
+---
+
+### Task 3: AgitationServer に `/agitation/window` エンドポイントを追加
+
+**Files:**
+- Modify: `backend/src/agitation_server.py`
+- Test: `backend/tests/test_agitation_server.py`
+
+- [ ] **Step 1: 失敗するテストを書く**
+
+`backend/tests/test_agitation_server.py` の末尾に追加：
+
+```python
+@pytest.mark.asyncio
+async def test_agitation_window_empty():
+    """ウィンドウ内にパルスなし → level=0"""
+    async with AsyncClient(
+        transport=ASGITransport(app=app), base_url="http://test"
+    ) as ac:
+        import time
+        t = time.time()
+        resp = await ac.get(f"/agitation/window?from_ts={t}&to_ts={t + 1}")
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["level"] == 0
+    assert "trend" in data
+    assert "peak" in data
+
+
+@pytest.mark.asyncio
+async def test_agitation_window_with_pulses():
+    """ウィンドウ内にパルスあり → level > 0"""
+    import time
+    async with AsyncClient(
+        transport=ASGITransport(app=app), base_url="http://test"
+    ) as ac:
+        t_start = time.time()
+        for _ in range(5):
+            await ac.post("/pulse")
+        t_end = time.time()
+        resp = await ac.get(f"/agitation/window?from_ts={t_start}&to_ts={t_end}")
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["level"] > 0
+```
+
+- [ ] **Step 2: テストが失敗することを確認**
+
+```bash
+cd backend && uv run pytest tests/test_agitation_server.py::test_agitation_window_empty -v
+```
+
+Expected: `FAILED` / 404
+
+- [ ] **Step 3: エンドポイントを実装**
+
+`backend/src/agitation_server.py` に追加：
+
+```python
+@app.get("/agitation/window")
+def get_agitation_window(from_ts: float, to_ts: float):
+    snap = engine.snapshot_window(from_ts, to_ts)
+    print(f"[Agitation] window({from_ts:.1f},{to_ts:.1f}) → level={snap['level']}%, trend={snap['trend']}", flush=True)
+    return snap
+```
+
+- [ ] **Step 4: 全テストが通ることを確認**
+
+```bash
+cd backend && uv run pytest tests/test_agitation_server.py -v
+```
+
+Expected: 全テスト PASSED
+
+- [ ] **Step 5: コミット**
+
+```bash
+git add backend/src/agitation_server.py backend/tests/test_agitation_server.py
+git commit -m "feat: add /agitation/window endpoint"
+```
+
+---
+
+## Chunk 2: LiveSessionManager
+
+### Task 4: `live_session.py` の骨格とモックテスト環境を作る
+
+**Files:**
+- Create: `backend/src/live_session.py`
+- Create: `backend/tests/test_live_session.py`
+
+- [ ] **Step 1: モッククライアントの設計を理解する**
+
+`google.genai` の Live API は以下のパターンで使う：
+
+```python
+async with client.aio.live.connect(model=MODEL, config=config) as session:
+    await session.send_realtime_input(audio=types.Blob(data=pcm, mime_type="audio/pcm;rate=16000"))
+    async for response in session.receive():
+        # response.data: audio chunk bytes
+        # response.tool_call: FunctionCall オブジェクト
+        # response.server_content.turn_complete: bool
+```
+
+テストではこの `session` をモックする。
+
+- [ ] **Step 2: モックと骨格テストを書く**
+
+新規ファイル `backend/tests/test_live_session.py` を作成：
+
+```python
+"""LiveSessionManager のユニットテスト（Gemini API はモック）。"""
+import asyncio
+import time
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from src.live_session import LiveSessionManager
+
+
+class FakeToolCall:
+    def __init__(self):
+        self.id = "call-001"
+        self.name = "get_agitation"
+        self.args = {}
+
+
+class FakeToolCallWrapper:
+    """live_session.py の `for call in response.tool_call.function_calls` に対応。"""
+    def __init__(self, call):
+        self.function_calls = [call]
+
+
+class FakeServerContent:
+    def __init__(self, audio_data=None, turn_complete=False):
+        self.parts = [MagicMock(inline_data=MagicMock(data=audio_data))] if audio_data else []
+        self.turn_complete = turn_complete
+
+
+class FakeResponse:
+    def __init__(self, audio_data=None, tool_call=None, turn_complete=False):
+        self.data = audio_data  # raw bytes or None
+        # tool_call は FakeToolCallWrapper でラップして .function_calls を持たせる
+        self.tool_call = FakeToolCallWrapper(tool_call) if tool_call else None
+        self.server_content = FakeServerContent(audio_data, turn_complete)
+
+
+def make_fake_session(responses):
+    """指定した responses を順に返す AsyncContextManager モック。"""
+    session = AsyncMock()
+
+    async def fake_receive():
+        for r in responses:
+            yield r
+
+    session.receive = fake_receive
+    session.send_realtime_input = AsyncMock()
+    session.send_tool_response = AsyncMock()
+    return session
+
+
+@pytest.fixture
+def manager():
+    return LiveSessionManager(agitation_api_url="http://localhost:8001")
+
+
+@pytest.mark.asyncio
+async def test_receive_yields_audio_chunk(manager):
+    """audio データが来たら audio_chunk イベントを yield する。"""
+    pcm = b"\x00\x01" * 100
+    responses = [
+        FakeResponse(audio_data=pcm),
+        FakeResponse(turn_complete=True),
+    ]
+    fake_session = make_fake_session(responses)
+    manager._session = fake_session
+
+    events = []
+    async for event in manager.receive():
+        events.append(event)
+
+    assert any(e["type"] == "audio_chunk" for e in events)
+    assert any(e["type"] == "turn_complete" for e in events)
+
+
+@pytest.mark.asyncio
+async def test_receive_sets_ai_speak_start_on_first_audio(manager):
+    """最初の audio chunk 受信時に _ai_speak_start がセットされる。"""
+    pcm = b"\x00\x01" * 100
+    responses = [FakeResponse(audio_data=pcm), FakeResponse(turn_complete=True)]
+    fake_session = make_fake_session(responses)
+    manager._session = fake_session
+    assert manager._ai_speak_start is None
+
+    async for _ in manager.receive():
+        pass
+
+    assert manager._ai_speak_start is not None
+
+
+@pytest.mark.asyncio
+async def test_receive_handles_tool_call(manager):
+    """tool_call を受け取ったら send_tool_response を呼ぶ。"""
+    tool_call = FakeToolCall()
+    responses = [
+        FakeResponse(tool_call=tool_call),
+        FakeResponse(turn_complete=True),
+    ]
+    fake_session = make_fake_session(responses)
+    manager._session = fake_session
+
+    with patch.object(manager, "_fetch_agitation_window", new_callable=AsyncMock) as mock_fetch:
+        mock_fetch.return_value = {"level": 42, "peak": 42, "trend": "rising"}
+        async for _ in manager.receive():
+            pass
+
+    fake_session.send_tool_response.assert_called_once()
+
+
+@pytest.mark.asyncio
+async def test_send_audio_calls_send_realtime_input(manager):
+    """send_audio() は send_realtime_input() を呼ぶ。"""
+    fake_session = make_fake_session([])
+    manager._session = fake_session
+    pcm = b"\x00" * 3200
+    await manager.send_audio(pcm)
+    fake_session.send_realtime_input.assert_called_once()
+```
+
+- [ ] **Step 3: テストが失敗することを確認**
+
+```bash
+cd backend && uv run pytest tests/test_live_session.py -v
+```
+
+Expected: `FAILED` / `ModuleNotFoundError: No module named 'src.live_session'`
+
+- [ ] **Step 4: コミット（テストのみ）**
+
+```bash
+git add backend/tests/test_live_session.py
+git commit -m "test: add LiveSessionManager unit tests (red)"
+```
+
+---
+
+### Task 5: `live_session.py` を実装する
+
+**Files:**
+- Create: `backend/src/live_session.py`
+
+- [ ] **Step 1: `live_session.py` を作成**
+
+```python
+"""
+Gemini Live API を使った占いセッション管理。
+- 1ターン = 1つの自然な応答（stage1/stage2 の区別なし）
+- get_agitation tool を AI が自律的に呼ぶ
+"""
+from __future__ import annotations
+
+import base64
+import os
+import time
+from typing import AsyncGenerator
+
+import httpx
+from google import genai
+from google.genai import types
+
+MODEL = "gemini-2.5-flash-live"
+AGITATION_API_URL = os.getenv("AGITATION_API_URL", "")
+
+SYSTEM_INSTRUCTION = """\
+あなたはAI手相占い師「ぱむぱむ」です。
+
+【基本姿勢】
+手の感情線・運命線・頭脳線・生命線を具体的に言及しながら語る。
+断言は避け「〜ではないですか」「〜が見えます」という仮説として語る。
+神秘的かつ低いトーンで、2〜3文で語る。
+
+【get_agitation ツールの使い方（最重要）】
+- 毎ターン必ず1回呼び出すこと
+- 呼び出すタイミングは「感情の核心に近づいた」と感じた瞬間（ターンの中盤〜後半）
+- 呼び出す前に一般的な読みを展開し、結果を見てから核心を突く
+- すぐに「センサーが〜」とは言わない。「体が正直に答えています」程度に留める
+
+【出力】
+2〜3文、必ず問いかけで締める。
+"""
+
+GET_AGITATION_DECLARATION = types.FunctionDeclaration(
+    name="get_agitation",
+    description=(
+        "ユーザーの手の振動センサーから身体的動揺度を読み取る。"
+        "占いの重要なタイミング（感情の核心に触れる直前）で呼び出すこと。"
+        "呼び出すタイミング自体が演出の一部。毎ターン1回は必ず呼び出すこと。"
+    ),
+    parameters=types.Schema(type=types.Type.OBJECT, properties={}),
+)
+
+
+class LiveSessionManager:
+    """Gemini Live API を使った占いセッション管理。"""
+
+    def __init__(
+        self,
+        agitation_api_url: str = AGITATION_API_URL,
+        client: genai.Client | None = None,
+    ):
+        self.agitation_api_url = agitation_api_url
+        self._client = client or genai.Client(api_key=os.getenv("GEMINI_API_KEY"))
+        self._session = None
+        self._ai_speak_start: float | None = None
+        self._text_history: list[dict] = []  # 切断復帰用（直近6ターン）
+        self._ctx = None  # async context manager
+
+    async def connect(self) -> None:
+        """Live API セッションを確立する。"""
+        config = types.LiveConnectConfig(
+            response_modalities=["AUDIO"],
+            system_instruction=SYSTEM_INSTRUCTION,
+            tools=[types.Tool(function_declarations=[GET_AGITATION_DECLARATION])],
+            context_window_compression=types.ContextWindowCompressionConfig(
+                trigger_tokens=100000,
+                sliding_window=types.SlidingWindow(target_tokens=80000),
+            ),
+            speech_config=types.SpeechConfig(
+                voice_config=types.VoiceConfig(
+                    prebuilt_voice_config=types.PrebuiltVoiceConfig(voice_name="Kore")
+                )
+            ),
+        )
+        self._ctx = self._client.aio.live.connect(model=MODEL, config=config)
+        self._session = await self._ctx.__aenter__()
+
+    async def disconnect(self) -> None:
+        """セッションを終了する。"""
+        if self._ctx:
+            await self._ctx.__aexit__(None, None, None)
+            self._ctx = None
+            self._session = None
+
+    async def send_audio(self, pcm_bytes: bytes) -> None:
+        """PCM 16kHz mono int16 を Live API へ送信。"""
+        self._ai_speak_start = None  # 次の AI 発話の start をリセット
+        await self._session.send_realtime_input(
+            audio=types.Blob(data=pcm_bytes, mime_type="audio/pcm;rate=16000")
+        )
+
+    async def receive(self) -> AsyncGenerator[dict, None]:
+        """
+        受信イベントを yield する:
+          {"type": "audio_chunk", "data": "<base64 PCM 24kHz>"}
+          {"type": "turn_complete"}
+        """
+        async for response in self._session.receive():
+            # audio chunk
+            if response.data:
+                if self._ai_speak_start is None:
+                    self._ai_speak_start = time.time()
+                yield {
+                    "type": "audio_chunk",
+                    "data": base64.b64encode(response.data).decode(),
+                }
+
+            # tool call
+            if response.tool_call:
+                for call in response.tool_call.function_calls:
+                    await self._handle_tool_call(call)
+
+            # turn complete
+            if (
+                response.server_content
+                and response.server_content.turn_complete
+            ):
+                yield {"type": "turn_complete"}
+                self._ai_speak_start = None
+
+    async def _handle_tool_call(self, call) -> None:
+        """get_agitation tool call を処理してラズパイに問い合わせ、結果を返す。"""
+        from_ts = self._ai_speak_start if self._ai_speak_start else time.time() - 3.0
+        to_ts = time.time()
+        snap = await self._fetch_agitation_window(from_ts, to_ts)
+        await self._session.send_tool_response(
+            function_responses=[
+                types.FunctionResponse(
+                    id=call.id,
+                    name=call.name,
+                    response=snap,
+                )
+            ]
+        )
+
+    async def _fetch_agitation_window(self, from_ts: float, to_ts: float) -> dict:
+        """ラズパイの /agitation/window を HTTP 呼び出し。失敗時はデフォルト値を返す。"""
+        if not self.agitation_api_url:
+            return {"level": 0, "peak": 0, "trend": "stable"}
+        try:
+            async with httpx.AsyncClient(timeout=2.0) as client:
+                resp = await client.get(
+                    f"{self.agitation_api_url}/agitation/window",
+                    params={"from_ts": from_ts, "to_ts": to_ts},
+                )
+                return resp.json()
+        except Exception as e:
+            print(f"[LiveSession] agitation fetch error: {e}", flush=True)
+            return {"level": 0, "peak": 0, "trend": "stable"}
+```
+
+- [ ] **Step 2: テストが通ることを確認**
+
+```bash
+cd backend && uv run pytest tests/test_live_session.py -v
+```
+
+Expected: 全テスト PASSED
+
+- [ ] **Step 3: コミット**
+
+```bash
+git add backend/src/live_session.py
+git commit -m "feat: implement LiveSessionManager with get_agitation tool"
+```
+
+---
+
+## Chunk 3: main.py エンドポイント更新
+
+### Task 6: `main.py` を Live API エンドポイントに置き換える
+
+**Files:**
+- Modify: `backend/src/main.py`
+- Test: `backend/tests/test_main.py`（新規）
+
+- [ ] **Step 1: 失敗するテストを書く**
+
+新規ファイル `backend/tests/test_main.py` を作成：
+
+```python
+"""main.py エンドポイントの統合テスト。LiveSessionManager はモック。"""
+import pytest
+from httpx import ASGITransport, AsyncClient
+from unittest.mock import AsyncMock, MagicMock, patch
+
+
+@pytest.fixture
+def mock_manager():
+    m = MagicMock()
+    m.connect = AsyncMock()
+    m.disconnect = AsyncMock()
+    m.send_audio = AsyncMock()
+
+    async def fake_receive():
+        yield {"type": "audio_chunk", "data": "AAEC"}
+        yield {"type": "turn_complete"}
+
+    m.receive = fake_receive
+    return m
+
+
+@pytest.mark.asyncio
+async def test_session_start_returns_session_id(mock_manager):
+    with patch("src.main.LiveSessionManager", return_value=mock_manager):
+        from src.main import app
+        async with AsyncClient(
+            transport=ASGITransport(app=app), base_url="http://test"
+        ) as ac:
+            resp = await ac.post("/api/session/start")
+    assert resp.status_code == 200
+    assert "session_id" in resp.json()
+
+
+@pytest.mark.asyncio
+async def test_audio_returns_sse(mock_manager):
+    with patch("src.main.LiveSessionManager", return_value=mock_manager):
+        from src.main import app, sessions
+        session_id = "test-session-123"
+        sessions[session_id] = mock_manager
+
+        async with AsyncClient(
+            transport=ASGITransport(app=app), base_url="http://test"
+        ) as ac:
+            resp = await ac.post(
+                f"/api/audio?session_id={session_id}",
+                content=b"\x00" * 3200,
+                headers={"Content-Type": "audio/octet-stream"},
+            )
+    assert resp.status_code == 200
+    assert "text/event-stream" in resp.headers["content-type"]
+
+
+@pytest.mark.asyncio
+async def test_audio_unknown_session_returns_404(mock_manager):
+    with patch("src.main.LiveSessionManager", return_value=mock_manager):
+        from src.main import app
+        async with AsyncClient(
+            transport=ASGITransport(app=app), base_url="http://test"
+        ) as ac:
+            resp = await ac.post(
+                "/api/audio?session_id=does-not-exist",
+                content=b"\x00" * 3200,
+            )
+    assert resp.status_code == 404
+
+
+@pytest.mark.asyncio
+async def test_session_delete(mock_manager):
+    with patch("src.main.LiveSessionManager", return_value=mock_manager):
+        from src.main import app, sessions
+        session_id = "del-session-456"
+        sessions[session_id] = mock_manager
+
+        async with AsyncClient(
+            transport=ASGITransport(app=app), base_url="http://test"
+        ) as ac:
+            resp = await ac.delete(f"/api/session?session_id={session_id}")
+    assert resp.status_code == 200
+    assert session_id not in sessions
+```
+
+- [ ] **Step 2: テストが失敗することを確認**
+
+```bash
+cd backend && uv run pytest tests/test_main.py -v
+```
+
+Expected: `FAILED` / 404 or import error
+
+- [ ] **Step 3: `main.py` を書き換える**
+
+`backend/src/main.py` を以下に置き換える：
+
+```python
+# backend/src/main.py
+# Docker コンテナで IPv6 が到達不能な環境向け: DNS 解決で IPv4 のみ返すように上書き
+import socket as _socket
+_orig_getaddrinfo = _socket.getaddrinfo
+def _ipv4_only(host, port, family=0, *a, **kw):
+    results = _orig_getaddrinfo(host, port, family, *a, **kw)
+    ipv4 = [r for r in results if r[0] == _socket.AF_INET]
+    return ipv4 if ipv4 else results
+_socket.getaddrinfo = _ipv4_only
+
+import json
+import uuid
+
+from fastapi import FastAPI, HTTPException, Request
+from fastapi.middleware.cors import CORSMiddleware
+from fastapi.responses import StreamingResponse
+from dotenv import load_dotenv
+
+from .live_session import LiveSessionManager
+
+load_dotenv()
+
+app = FastAPI()
+app.add_middleware(
+    CORSMiddleware,
+    allow_origins=["*"],
+    allow_methods=["GET", "POST", "DELETE", "OPTIONS"],
+    allow_headers=["*"],
+)
+
+# セッション管理（session_id → LiveSessionManager）
+sessions: dict[str, LiveSessionManager] = {}
+
+
+def _sse(event: dict) -> str:
+    return f"data: {json.dumps(event, ensure_ascii=False)}\n\n"
+
+
+@app.get("/health")
+async def health():
+    return {"status": "ok"}
+
+
+@app.post("/api/session/start")
+async def session_start():
+    """Live API セッションを確立し session_id を返す。"""
+    session_id = str(uuid.uuid4())
+    manager = LiveSessionManager()
+    await manager.connect()
+    sessions[session_id] = manager
+    print(f"[Main] session started: {session_id}", flush=True)
+    return {"session_id": session_id}
+
+
+@app.post("/api/audio")
+async def receive_audio(session_id: str, request: Request):
+    """PCM 音声を受け取り、Live API 経由で応答を SSE でストリーム返却。"""
+    manager = sessions.get(session_id)
+    if not manager:
+        raise HTTPException(status_code=404, detail="session not found")
+
+    pcm_bytes = await request.body()
+    await manager.send_audio(pcm_bytes)
+
+    async def generate():
+        async for event in manager.receive():
+            yield _sse(event)
+
+    return StreamingResponse(
+        generate(),
+        media_type="text/event-stream",
+        headers={"Cache-Control": "no-cache", "X-Accel-Buffering": "no"},
+    )
+
+
+@app.delete("/api/session")
+async def session_delete(session_id: str):
+    """セッションを終了・破棄する。"""
+    manager = sessions.pop(session_id, None)
+    if manager:
+        await manager.disconnect()
+    print(f"[Main] session deleted: {session_id}", flush=True)
+    return {"ok": True}
+```
+
+- [ ] **Step 4: テストが通ることを確認**
+
+```bash
+cd backend && uv run pytest tests/test_main.py -v
+```
+
+Expected: 全テスト PASSED
+
+- [ ] **Step 5: 全バックエンドテストが通ることを確認**
+
+```bash
+cd backend && uv run pytest tests/ -v
+```
+
+Expected: 全テスト PASSED（`test_two_stage_session.py` は既存のままなので影響なし）
+
+- [ ] **Step 6: コミット**
+
+```bash
+git add backend/src/main.py backend/tests/test_main.py
+git commit -m "feat: replace main.py with Live API session endpoints"
+```
+
+---
+
+## Chunk 4: フロントエンド更新
+
+### Task 7: AudioWorklet プロセッサを作成する
+
+**Files:**
+- Create: `frontend/public/pcm-processor.js`
+
+フロントエンドのテストは手動（ブラウザ）で確認する。
+
+- [ ] **Step 1: AudioWorklet プロセッサを作成**
+
+新規ファイル `frontend/public/pcm-processor.js` を作成：
+
+```javascript
+/**
+ * AudioWorklet プロセッサ：マイク入力を 16kHz mono int16 PCM に変換して送信する。
+ * AudioContext sampleRate=16000 で使うこと。
+ */
+class PcmProcessor extends AudioWorkletProcessor {
+  process(inputs) {
+    const input = inputs[0]
+    if (!input || !input[0]) return true
+    const float32 = input[0]
+    // float32 [-1, 1] → int16
+    const int16 = new Int16Array(float32.length)
+    for (let i = 0; i < float32.length; i++) {
+      int16[i] = Math.max(-32768, Math.min(32767, float32[i] * 32768))
+    }
+    this.port.postMessage(int16.buffer, [int16.buffer])
+    return true
+  }
+}
+
+registerProcessor('pcm-processor', PcmProcessor)
+```
+
+- [ ] **Step 2: コミット**
+
+```bash
+git add frontend/public/pcm-processor.js
+git commit -m "feat: add AudioWorklet PCM processor"
+```
+
+---
+
+### Task 8: `SessionPage.jsx` と `App.jsx` の `aiText` 依存を除去する
+
+Live API は音声のみを返すため `aiText` は不要になる。
+`SessionPage.jsx` の `KirbyMock` アニメーションは `turn === 'ai'` で制御する。
+
+**Files:**
+- Modify: `frontend/src/pages/SessionPage.jsx`
+- Modify: `frontend/src/App.jsx`
+
+- [ ] **Step 1: `SessionPage.jsx` を修正**
+
+`frontend/src/pages/SessionPage.jsx` の以下の行を変更：
+
+```jsx
+// 変更前
+<KirbyMock isTalking={turn === 'ai' && aiText.length > 0} />
+<div className="mt-8 max-w-md text-center min-h-[4rem] px-4">
+  <p className="text-lg leading-relaxed">{aiText}</p>
+</div>
+
+// 変更後
+<KirbyMock isTalking={turn === 'ai'} />
+<div className="mt-8 max-w-md text-center min-h-[4rem] px-4" />
+```
+
+関数シグネチャからも `aiText` を削除：
+
+```jsx
+// 変更前
+export function SessionPage({ turn, aiText, vadError, timeLeft, onEnd }) {
+
+// 変更後
+export function SessionPage({ turn, vadError, timeLeft, onEnd }) {
+```
+
+- [ ] **Step 2: `App.jsx` を修正**
+
+`frontend/src/App.jsx` の以下の行を変更：
+
+```jsx
+// 変更前
+const { turn, aiText, vadError, timeLeft } = useSession({
+
+// 変更後
+const { turn, vadError, timeLeft } = useSession({
+```
+
+```jsx
+// 変更前（SessionPage への props）
+<SessionPage
+  turn={turn}
+  aiText={aiText}
+  vadError={vadError}
+  timeLeft={timeLeft}
+  onEnd={() => setPage('end')}
+/>
+
+// 変更後
+<SessionPage
+  turn={turn}
+  vadError={vadError}
+  timeLeft={timeLeft}
+  onEnd={() => setPage('end')}
+/>
+```
+
+- [ ] **Step 3: コミット**
+
+```bash
+git add frontend/src/pages/SessionPage.jsx frontend/src/App.jsx
+git commit -m "refactor: remove aiText from SessionPage (Live API is audio-only)"
+```
+
+---
+
+### Task 10: `useSession.js` を Live API 対応に書き換える
+
+**Files:**
+- Modify: `frontend/src/hooks/useSession.js`
+
+- [ ] **Step 1: `useSession.js` を書き換える**
+
+`frontend/src/hooks/useSession.js` を以下に置き換える：
+
+```javascript
+/**
+ * useSession.js
+ * Live API 対応版:
+ * - AudioWorklet で PCM 16kHz をキャプチャ
+ * - POST /api/audio で送信 → SSE で audio_chunk (base64 PCM 24kHz) を受信
+ * - Web Audio API で PCM チャンクをスケジュール再生
+ */
+import { useCallback, useEffect, useRef, useState } from 'react'
+
+const BACKEND_URL = import.meta.env.VITE_BACKEND_URL || ''
+const MAX_RECORD_SECONDS = 10
+
+async function* readSseStream(response) {
+  const reader = response.body.getReader()
+  const decoder = new TextDecoder()
+  let buffer = ''
+  while (true) {
+    const { done, value } = await reader.read()
+    if (done) break
+    buffer += decoder.decode(value, { stream: true })
+    const lines = buffer.split('\n')
+    buffer = lines.pop()
+    for (const line of lines) {
+      if (line.startsWith('data: ')) {
+        try { yield JSON.parse(line.slice(6)) } catch { /* ignore */ }
+      }
+    }
+  }
+}
+
+export function useSession({ enabled = false } = {}) {
+  const [turn, setTurn] = useState('user')
+  const [vadError, setVadError] = useState(null)
+  const [timeLeft, setTimeLeft] = useState(MAX_RECORD_SECONDS)
+
+  const sessionIdRef = useRef(null)
+  const audioCtxRef = useRef(null)       // 再生用 AudioContext (24kHz)
+  const captureCtxRef = useRef(null)     // キャプチャ用 AudioContext (16kHz)
+  const workletNodeRef = useRef(null)
+  const streamRef = useRef(null)
+  const pcmChunksRef = useRef([])        // 録音中の PCM chunks
+  const nextPlayTimeRef = useRef(0)      // 次の audio chunk を再生する時刻
+  const countdownRef = useRef(null)
+  const stopTimerRef = useRef(null)
+  const enabledRef = useRef(enabled)
+
+  useEffect(() => { enabledRef.current = enabled }, [enabled])
+
+  // ── セッション開始 ──────────────────────────────────────
+  const startSession = useCallback(async () => {
+    try {
+      const resp = await fetch(`${BACKEND_URL}/api/session/start`, { method: 'POST' })
+      const { session_id } = await resp.json()
+      sessionIdRef.current = session_id
+      console.log('[useSession] session started:', session_id)
+    } catch (err) {
+      setVadError('セッション開始失敗: ' + err.message)
+    }
+  }, [])
+
+  // ── セッション終了 ──────────────────────────────────────
+  const stopSession = useCallback(async () => {
+    const sid = sessionIdRef.current
+    if (!sid) return
+    sessionIdRef.current = null
+    try {
+      await fetch(`${BACKEND_URL}/api/session?session_id=${sid}`, { method: 'DELETE' })
+    } catch { /* ignore */ }
+  }, [])
+
+  // ── 録音開始 ───────────────────────────────────────────
+  const startRecording = useCallback(async () => {
+    setVadError(null)
+    const mediaDevices = globalThis.navigator?.mediaDevices
+    if (!mediaDevices?.getUserMedia) {
+      setVadError('マイクが利用できません。HTTPS または localhost で開いてください。')
+      return
+    }
+    try {
+      if (!streamRef.current) {
+        streamRef.current = await mediaDevices.getUserMedia({ audio: true })
+      }
+      // キャプチャ用 AudioContext (16kHz)
+      if (!captureCtxRef.current || captureCtxRef.current.state === 'closed') {
+        captureCtxRef.current = new AudioContext({ sampleRate: 16000 })
+      }
+      const captureCtx = captureCtxRef.current
+      await captureCtx.audioWorklet.addModule('/pcm-processor.js')
+
+      const source = captureCtx.createMediaStreamSource(streamRef.current)
+      const worklet = new AudioWorkletNode(captureCtx, 'pcm-processor')
+      workletNodeRef.current = worklet
+
+      pcmChunksRef.current = []
+      worklet.port.onmessage = (e) => {
+        pcmChunksRef.current.push(new Int16Array(e.data))
+      }
+      source.connect(worklet)
+      worklet.connect(captureCtx.destination)
+
+      setTimeLeft(MAX_RECORD_SECONDS)
+      countdownRef.current = setInterval(
+        () => setTimeLeft((t) => Math.max(0, t - 1)),
+        1000,
+      )
+      stopTimerRef.current = setTimeout(() => stopRecording(), MAX_RECORD_SECONDS * 1000)
+    } catch (err) {
+      setVadError(err?.message ?? 'マイク初期化失敗')
+    }
+  }, []) // eslint-disable-line react-hooks/exhaustive-deps
+
+  // ── 録音停止 → 送信 ────────────────────────────────────
+  const stopRecording = useCallback(async () => {
+    if (countdownRef.current) { clearInterval(countdownRef.current); countdownRef.current = null }
+    if (stopTimerRef.current) { clearTimeout(stopTimerRef.current); stopTimerRef.current = null }
+    setTimeLeft(MAX_RECORD_SECONDS)
+
+    const worklet = workletNodeRef.current
+    if (worklet) { worklet.disconnect(); workletNodeRef.current = null }
+
+    const chunks = pcmChunksRef.current
+    pcmChunksRef.current = []
+    if (!enabledRef.current || chunks.length === 0) { setTurn('user'); return }
+
+    // Int16Array を結合して ArrayBuffer に
+    const total = chunks.reduce((s, c) => s + c.length, 0)
+    const merged = new Int16Array(total)
+    let offset = 0
+    for (const c of chunks) { merged.set(c, offset); offset += c.length }
+
+    await sendAudio(merged.buffer)
+  }, []) // eslint-disable-line react-hooks/exhaustive-deps
+
+  // ── PCM 送信 → SSE 受信 → 再生 ─────────────────────────
+  const sendAudio = useCallback(async (pcmBuffer) => {
+    const sid = sessionIdRef.current
+    if (!sid) return
+    setTurn('ai')
+
+    // 再生用 AudioContext (24kHz)
+    if (!audioCtxRef.current || audioCtxRef.current.state === 'closed') {
+      audioCtxRef.current = new AudioContext({ sampleRate: 24000 })
+    }
+    const audioCtx = audioCtxRef.current
+    nextPlayTimeRef.current = audioCtx.currentTime
+
+    try {
+      const resp = await fetch(`${BACKEND_URL}/api/audio?session_id=${sid}`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'audio/octet-stream' },
+        body: pcmBuffer,
+      })
+      for await (const event of readSseStream(resp)) {
+        if (event.type === 'audio_chunk') {
+          // base64 → Int16Array → Float32Array → AudioBuffer → スケジュール再生
+          const raw = atob(event.data)
+          const int16 = new Int16Array(raw.length / 2)
+          for (let i = 0; i < int16.length; i++) {
+            int16[i] = (raw.charCodeAt(i * 2)) | (raw.charCodeAt(i * 2 + 1) << 8)
+          }
+          const float32 = new Float32Array(int16.length)
+          for (let i = 0; i < int16.length; i++) {
+            float32[i] = int16[i] / 32768
+          }
+          const buffer = audioCtx.createBuffer(1, float32.length, 24000)
+          buffer.copyToChannel(float32, 0)
+          const source = audioCtx.createBufferSource()
+          source.buffer = buffer
+          source.connect(audioCtx.destination)
+          const startAt = Math.max(audioCtx.currentTime, nextPlayTimeRef.current)
+          source.start(startAt)
+          nextPlayTimeRef.current = startAt + buffer.duration
+        } else if (event.type === 'turn_complete') {
+          // 再生終了後にユーザーターンへ
+          const remaining = nextPlayTimeRef.current - audioCtx.currentTime
+          setTimeout(() => setTurn('user'), Math.max(0, remaining * 1000))
+        }
+      }
+    } catch (err) {
+      console.error('[useSession] sendAudio error:', err)
+      setTurn('user')
+    }
+  }, [])
+
+  // ── ライフサイクル ─────────────────────────────────────
+  useEffect(() => {
+    if (!enabled) {
+      stopSession()
+      setVadError(null)
+      setTimeLeft(MAX_RECORD_SECONDS)
+      setTurn('user')
+      return
+    }
+    startSession()
+  }, [enabled, startSession, stopSession])
+
+  useEffect(() => {
+    if (!enabled) return
+    if (turn === 'user') {
+      startRecording()
+    } else {
+      if (workletNodeRef.current) { workletNodeRef.current.disconnect(); workletNodeRef.current = null }
+    }
+  }, [enabled, turn, startRecording])
+
+  useEffect(() => {
+    return () => {
+      if (countdownRef.current) clearInterval(countdownRef.current)
+      if (stopTimerRef.current) clearTimeout(stopTimerRef.current)
+      streamRef.current?.getTracks().forEach((t) => t.stop())
+      captureCtxRef.current?.close()
+      audioCtxRef.current?.close()
+    }
+  }, [])
+
+  return { turn, vadError, timeLeft }
+}
+```
+
+- [ ] **Step 2: コミット**
+
+```bash
+git add frontend/src/hooks/useSession.js
+git commit -m "feat: rewrite useSession for Live API (AudioWorklet + Web Audio API)"
+```
+
+---
+
+### Task 11: フロントエンド動作確認
+
+**ブラウザ手動テスト（Chrome 推奨）**
+
+- [ ] **Step 1: バックエンドを起動**
+
+```bash
+cd backend && uv run uvicorn src.main:app --reload --port 8000
+```
+
+- [ ] **Step 2: フロントエンドを起動**
+
+```bash
+cd frontend && npm run dev
+```
+
+- [ ] **Step 3: Chrome DevTools で確認**
+
+1. `http://localhost:5173` を開く
+2. Network タブで `POST /api/session/start` が 200 を返すことを確認
+3. 話しかけて `POST /api/audio` が SSE を返すことを確認
+4. Console に `[useSession] session started: <uuid>` が出ることを確認
+5. 音声が再生されることを確認（first audio まで ~2-3s が目標）
+6. agitation server が動いていれば、AI がコールドリーディングで言及することを確認
+
+- [ ] **Step 4: 問題なければコミット**
+
+```bash
+git add -A
+git commit -m "feat: Live API migration complete"
+```
+
+---
+
+## 最終確認
+
+- [ ] **全バックエンドテストが通る**
+
+```bash
+cd backend && uv run pytest tests/ -v
+```
+
+Expected: 全テスト PASSED
+
+- [ ] **プロンプトチューニングタスクを登録する**
+
+実装完了後、以下の内容で別ブレストセッションを行う：
+- agitation レベル別のトーン調整
+- tool call タイミングの誘導強化（WHEN_IDLE vs blocking の選択）
+- コールドリーディング精度向上

--- a/docs/superpowers/specs/2026-03-14-live-api-latency-design.md
+++ b/docs/superpowers/specs/2026-03-14-live-api-latency-design.md
@@ -26,9 +26,9 @@ stage1 再生終了 → text gen (~5s) → TTS gen (~5s) → stage2 audio
 
 ## 目標
 
-- Stage1 first audio: ~15s → ~2s
+- Stage1 first audio: ~15s → ~2s（ネットワーク状況により前後する）
 - Stage2 gap（stage1終了〜stage2再生）: ~10s → 0s（1ターン統合）
-- 会話履歴の維持
+- 会話履歴の維持（Live API セッション内で自動保持）
 - agitation データをコールドリーディング的なタイミングで活用
 
 ---
@@ -40,35 +40,44 @@ stage1 再生終了 → text gen (~5s) → TTS gen (~5s) → stage2 audio
 ```
 [Pico] → serial → [serial_reader] → POST /pulse
                                           ↓
-                                  [AgitationEngine]
+                                  [AgitationEngine]（Raspberry Pi）
                                   deque[timestamp] に蓄積
-                                  /agitation/window?from=X&to=Y
-
-[Frontend]                        [Backend: FastAPI]
-  Web Audio API         ←──────   Gemini Live API セッション
-  PCM チャンク再生                  ↑
-  turn タイムスタンプ記録  ──────→  session.send_tool_response()
+                                  GET /agitation/window?from=X&to=Y ←──┐
+                                                                         │HTTP
+[Frontend]                        [Backend: FastAPI]                     │
+  AudioWorklet で PCM キャプチャ   Gemini Live API セッション             │
+  fetch POST /api/audio ────────→  send_realtime_input(PCM 16kHz)       │
+  SSE で audio_chunk 受信 ←──────  receive() ループ                      │
+  Web Audio API で PCM 再生         └─ tool call 受信時 ──────────────────┘
+                                       send_tool_response(agitation)
 ```
 
 ### セッションライフサイクル
 
 ```
 占いセッション開始（1回）
+  └─ POST /api/session/start → {"session_id": "<uuid>"}
   └─ client.aio.live.connect(model='gemini-2.5-flash-live', config)
        └─ context window compression 有効（15分制限を回避）
        └─ get_agitation tool を登録
-       └─ セッション全体を通じて継続（WebSocket 持続）
+       └─ セッション全体を通じて WebSocket 持続（履歴は API 側が自動保持）
 
 [ターンごと]
-  1. ユーザー音声 PCM を send_realtime_input() でストリーム送信
-  2. AI が応答生成開始 → first audio ~2s で到着
-  3. AI が適切なタイミングで get_agitation() を tool call
-  4. Backend が AgitationEngine に window query → 結果を send_tool_response()
-  5. AI が agitation 情報を織り交ぜて応答を完成
-  6. turn_end イベントでユーザーターンへ
+  1. Frontend: AudioWorklet で PCM(16kHz mono int16) をキャプチャ
+  2. Frontend: POST /api/audio?session_id=<uuid> に PCM blob を送信
+  3. Backend: send_realtime_input() で Gemini へ転送
+  4. Gemini: 応答生成開始 → first audio チャンク ~2s で到着
+             ★ 最初の audio チャンク到着時 _ai_speak_start = time.time() をセット
+  5. Gemini: 任意のタイミングで get_agitation() を tool call
+  6. Backend: GET /agitation/window?from=_ai_speak_start&to=now をラズパイへ HTTP 呼び出し
+             → send_tool_response(level, peak, trend)
+  7. Gemini: agitation 情報を織り交ぜて応答を完成
+  8. Backend: SSE で audio_chunk（base64 PCM 24kHz）を Frontend へ逐次送信
+  9. Frontend: Web Audio API で PCM チャンクをスケジュール再生
+  10. turn_complete イベントでユーザーターンへ
 
 セッション切断時：
-  └─ resumption token で再接続
+  └─ resumption token で再接続（2時間以内有効）
   └─ 直近6ターンのテキスト履歴を system_instruction に埋め込んで補完
 ```
 
@@ -78,16 +87,26 @@ stage1 再生終了 → text gen (~5s) → TTS gen (~5s) → stage2 audio
 
 ### 1. AgitationEngine の拡張（`agitation_engine.py`）
 
-追加メソッド：
+既存の `trend` プロパティのロジックを `_calc_trend(level: int) -> str` として切り出し、
+`snapshot_window` と共用する。
 
 ```python
+def _calc_trend(self, level: int) -> str:
+    diff = level - self._previous_level
+    if diff > 10:
+        return "rising"
+    elif diff < -10:
+        return "falling"
+    return "stable"
+
 def snapshot_window(self, from_ts: float, to_ts: float) -> dict:
-    """指定期間内のパルスから level/peak/trend を算出。"""
+    """指定期間内のパルスから level/peak/trend を算出。_previous_level は更新しない。"""
     pulses_in_window = [t for t in self._pulses if from_ts <= t <= to_ts]
     level = min(100, int(len(pulses_in_window) / self.max_pulses * 100))
-    peak = level  # window内のピーク（将来的に細分化可）
-    return {"level": level, "peak": peak, "trend": self._calc_trend(level)}
+    return {"level": level, "peak": level, "trend": self._calc_trend(level)}
 ```
+
+既存の `trend` プロパティは `self._calc_trend(self.level)` を使うよう変更。
 
 ### 2. Agitation Server の拡張（`agitation_server.py`）
 
@@ -104,68 +123,127 @@ GET /agitation/window?from=<unix_sec>&to=<unix_sec>
 class LiveSessionManager:
     """Gemini Live API を使った占いセッション管理。"""
 
-    # セッション設定
     MODEL = "gemini-2.5-flash-live"
-    TOOLS = [get_agitation_tool_declaration]
 
-    # 状態管理
-    _session: BidiGenerateContentSession
-    _ai_speak_start: float | None  # AI発話開始タイムスタンプ
-    _text_history: list[dict]      # 切断復帰用テキスト履歴（直近6ターン）
+    def __init__(self, agitation_api_url: str):
+        self.agitation_api_url = agitation_api_url
+        self._session = None
+        self._ai_speak_start: float | None = None  # 最初の audio chunk 到着時にセット
+        self._text_history: list[dict] = []         # 切断復帰用（直近6ターン分のテキスト）
 
-    async def start(self): ...     # セッション確立
-    async def send_audio(self, pcm_bytes: bytes): ...  # ユーザー音声送信
-    async def receive(self) -> AsyncGenerator[dict, None]: ...  # 応答受信
+    async def connect(self) -> None:
+        """Live API セッションを確立する。"""
+        ...
+
+    async def send_audio(self, pcm_bytes: bytes) -> None:
+        """PCM 16kHz mono int16 を send_realtime_input() で送信。"""
+        ...
+
+    async def receive(self) -> AsyncGenerator[dict, None]:
+        """
+        受信イベントを yield する。
+        - {"type": "audio_chunk", "data": "<base64 PCM 24kHz>"}
+        - {"type": "turn_complete"}
+        最初の audio_chunk 受信時に _ai_speak_start をセット。
+        tool_call を受け取ったら _handle_tool_call() を呼んで処理。
+        """
+        ...
+
     async def _handle_tool_call(self, call) -> None:
-        # get_agitation() が呼ばれたとき
-        # window = [ai_speak_start, now] で agitation を取得して返す
+        """
+        get_agitation() tool call 処理。
+        window = [_ai_speak_start, time.time()] でラズパイへ HTTP クエリ。
+        _ai_speak_start が None の場合は現在時刻から 3s 前をフォールバックに使用。
+        """
+        from_ts = self._ai_speak_start or (time.time() - 3.0)
+        to_ts = time.time()
+        snap = await self._fetch_agitation_window(from_ts, to_ts)
+        await self._session.send_tool_response(
+            function_responses=[FunctionResponse(
+                id=call.id, name="get_agitation", response=snap
+            )]
+        )
+
+    async def _fetch_agitation_window(self, from_ts: float, to_ts: float) -> dict:
+        """ラズパイの /agitation/window を HTTP 呼び出し。"""
         ...
 ```
 
 #### get_agitation tool 定義
 
 ```python
-get_agitation_tool = {
-    "name": "get_agitation",
-    "description": (
+get_agitation_tool = FunctionDeclaration(
+    name="get_agitation",
+    description=(
         "ユーザーの手の振動センサーから身体的動揺度を読み取る。"
         "占いの重要なタイミング（感情の核心に触れる直前）で呼び出すこと。"
         "呼び出すタイミング自体が演出の一部であり、"
         "AI が最もドラマチックな瞬間を選ぶこと。"
+        "毎ターン1回は必ず呼び出すこと。"
     ),
-    "parameters": {"type": "object", "properties": {}},
-    "behavior": "NON_BLOCKING",
-    "scheduling": "WHEN_IDLE",
-}
+    parameters={"type": "object", "properties": {}},
+)
 ```
+
+**scheduling について：** `WHEN_IDLE` は応答生成の自然な間で呼ばれる。
+system_instruction で「必ず1回呼ぶ」と指示することで、
+生成開始直後ではなく中盤以降に呼ばれるよう誘導する。
+`WHEN_IDLE` を使わず blocking にする場合は生成が一時停止するが、
+コールドリーディング的な「間」として逆に演出になりうる。実装時に両方試すこと。
 
 #### tool call 時のウィンドウ
 
 | タイミング | 取得ウィンドウ | 意味 |
 |---|---|---|
-| AI が tool call した時点 | `[ai_speak_start, now]` | AIが話し始めてからの反応 |
+| AI が tool call した時点 | `[_ai_speak_start, now]` | AIが話し始めてからのユーザー反応 |
 
 ### 4. バックエンドエンドポイント（`main.py`）
 
 ```
-POST /api/session/start  → Live セッション確立、session_id を返す
-POST /api/audio          → PCM bytes 送信 → SSE で音声チャンク + イベントを返す
-DELETE /api/session      → セッション終了
+POST /api/session/start
+  → {"session_id": "<uuid>"}
+  → LiveSessionManager を生成・接続し、uuid をキーに dict 管理
+  → session が存在しない場合のみ新規作成（同時セッションは1つのみ）
+
+POST /api/audio?session_id=<uuid>
+  → body: PCM blob (audio/octet-stream, 16kHz mono int16)
+  → 該当セッションに send_audio() → receive() を SSE でストリーム
+  → session_id が不正な場合は 404
+
+DELETE /api/session?session_id=<uuid>
+  → セッション終了・破棄
 ```
 
-音声チャンクは SSE で `audio_chunk` イベントとして送信（base64 PCM）。
+**削除されるもの：**
+- `app.mount("/audio", StaticFiles(...))` を削除（WAV ファイル配信が不要になる）
+- `backend/assets/audio/tts/` ディレクトリへの書き込みが不要になる
+- `TwoStageSessionManager` のインスタンス化を削除
+
+音声チャンクは SSE で逐次送信：
+```
+data: {"type": "audio_chunk", "data": "<base64 PCM 24kHz mono>"}
+data: {"type": "turn_complete"}
+```
 
 ### 5. フロントエンド（`useSession.js`）
 
-変更点：
-- `new Audio(url)` による WAV 再生 → **Web Audio API** による PCM ストリーム再生
-- AI 発話開始タイムスタンプを `session_id` と共にバックエンドに通知
-- 音声チャンクを受け取り次第キューに追加して再生
+**ユーザー音声キャプチャ（現状変更）：**
+- 現状: `MediaRecorder` → webm blob
+- 変更後: **AudioWorklet**（または ScriptProcessorNode）で raw PCM 16kHz mono int16 をキャプチャ
+  - `AudioContext({ sampleRate: 16000 })` で作成
+  - AudioWorklet が 16bit int に変換して blob として送信
 
-```javascript
-// PCM チャンク受信 → AudioBuffer に変換 → AudioContext でスケジュール再生
-const audioCtx = new AudioContext({ sampleRate: 24000 })
-```
+**AI 音声再生（現状変更）：**
+- 現状: `new Audio(url)` で WAV ファイルを再生
+- 変更後: **Web Audio API** で PCM チャンクをスケジュール再生
+  ```javascript
+  const audioCtx = new AudioContext({ sampleRate: 24000 })
+  // audio_chunk イベントごとに AudioBuffer を作成してキューに追加
+  ```
+
+**セッション管理：**
+- 起動時に `POST /api/session/start` → `session_id` を保持
+- 以降の `POST /api/audio?session_id=<uuid>` に付与
 
 ---
 
@@ -183,7 +261,7 @@ Live API のセッション開始時に1回設定。
 
 【get_agitation ツールの使い方（最重要）】
 - 毎ターン必ず1回呼び出すこと
-- 呼び出すタイミングは「感情の核心に近づいた」と感じた瞬間
+- 呼び出すタイミングは「感情の核心に近づいた」と感じた瞬間（ターンの中盤〜後半）
 - 呼び出す前に一般的な読みを展開し、結果を見てから核心を突く
 - すぐに「センサーが〜」とは言わない。「体が正直に答えています」程度に留める
 
@@ -205,14 +283,14 @@ Live API のセッション開始時に1回設定。
 
 | ファイル | 変更種別 | 規模 |
 |---|---|---|
-| `backend/src/agitation_engine.py` | 追加 | +20行 |
+| `backend/src/agitation_engine.py` | 変更（`_calc_trend` 切り出し + `snapshot_window` 追加） | +25行 |
 | `backend/src/agitation_server.py` | 追加 | +10行 |
 | `backend/src/live_session.py` | 新規 | ~250行 |
-| `backend/src/two_stage_session.py` | 廃止（保持） | - |
-| `backend/src/main.py` | 変更 | ~60行変更 |
-| `frontend/src/hooks/useSession.js` | 変更 | ~100行変更 |
+| `backend/src/two_stage_session.py` | 廃止（ファイルは保持） | - |
+| `backend/src/main.py` | 変更（StaticFiles削除・新エンドポイント追加） | ~60行変更 |
+| `frontend/src/hooks/useSession.js` | 変更（AudioWorklet + Web Audio API） | ~120行変更 |
 
-合計：約 450〜500 行
+合計：約 465〜520 行
 
 ---
 
@@ -220,8 +298,10 @@ Live API のセッション開始時に1回設定。
 
 | リスク | 対策 |
 |---|---|
-| Live API セッション15分制限 | context window compression を有効化 |
-| セッション切断 | resumption token + テキスト履歴で復帰 |
-| tool call タイミングが不自然 | `WHEN_IDLE` + system_instruction で誘導 |
-| Web Audio API ブラウザ互換性 | Chrome/Safari の AudioContext で動作確認済み |
-| PCM フォーマット変換 | 入力: 16kHz mono / 出力: 24kHz mono で統一 |
+| Live API セッション15分制限 | context window compression を有効化（`BidiGenerateContentSetup` で設定） |
+| セッション切断 | resumption token（2時間有効）+ テキスト履歴で復帰 |
+| tool call タイミング制御（`WHEN_IDLE` vs blocking） | 両方試して演出として自然な方を採用 |
+| Web Audio API ブラウザ互換性 | Chrome/Safari の AudioContext で動作確認 |
+| PCM フォーマット | 入力: 16kHz mono int16 / 出力: 24kHz mono int16 で統一 |
+| agitation server（ラズパイ）への HTTP 遅延 | timeout=2s で打ち切り、失敗時は `{"level":0,"trend":"stable"}` を返す |
+| context window compression の利用可否 | 実装時に `gemini-2.5-flash-live` での対応を確認 |

--- a/docs/superpowers/specs/2026-03-14-live-api-latency-design.md
+++ b/docs/superpowers/specs/2026-03-14-live-api-latency-design.md
@@ -1,0 +1,227 @@
+# PalmPalm レイテンシ改善設計：Gemini Live API + Tool Use
+
+**日付:** 2026-03-14
+**ステータス:** 承認済み
+
+---
+
+## 背景と課題
+
+現状のレスポンスフロー（直列 API 呼び出し）：
+
+```
+音声受信 → text gen (~5s) → TTS gen (~5s) → stage1 audio
+                                              ↑ ~15秒
+
+stage1 再生終了 → text gen (~5s) → TTS gen (~5s) → stage2 audio
+                                                     ↑ さらに ~10秒
+```
+
+原因：
+- `generate_content`（テキスト）と `generate_content`（TTS）が直列
+- `run_in_executor` による同期クライアントのスレッド実行
+- 2段階構造のため API 呼び出しが合計4回
+
+---
+
+## 目標
+
+- Stage1 first audio: ~15s → ~2s
+- Stage2 gap（stage1終了〜stage2再生）: ~10s → 0s（1ターン統合）
+- 会話履歴の維持
+- agitation データをコールドリーディング的なタイミングで活用
+
+---
+
+## アーキテクチャ
+
+### 全体像
+
+```
+[Pico] → serial → [serial_reader] → POST /pulse
+                                          ↓
+                                  [AgitationEngine]
+                                  deque[timestamp] に蓄積
+                                  /agitation/window?from=X&to=Y
+
+[Frontend]                        [Backend: FastAPI]
+  Web Audio API         ←──────   Gemini Live API セッション
+  PCM チャンク再生                  ↑
+  turn タイムスタンプ記録  ──────→  session.send_tool_response()
+```
+
+### セッションライフサイクル
+
+```
+占いセッション開始（1回）
+  └─ client.aio.live.connect(model='gemini-2.5-flash-live', config)
+       └─ context window compression 有効（15分制限を回避）
+       └─ get_agitation tool を登録
+       └─ セッション全体を通じて継続（WebSocket 持続）
+
+[ターンごと]
+  1. ユーザー音声 PCM を send_realtime_input() でストリーム送信
+  2. AI が応答生成開始 → first audio ~2s で到着
+  3. AI が適切なタイミングで get_agitation() を tool call
+  4. Backend が AgitationEngine に window query → 結果を send_tool_response()
+  5. AI が agitation 情報を織り交ぜて応答を完成
+  6. turn_end イベントでユーザーターンへ
+
+セッション切断時：
+  └─ resumption token で再接続
+  └─ 直近6ターンのテキスト履歴を system_instruction に埋め込んで補完
+```
+
+---
+
+## コンポーネント設計
+
+### 1. AgitationEngine の拡張（`agitation_engine.py`）
+
+追加メソッド：
+
+```python
+def snapshot_window(self, from_ts: float, to_ts: float) -> dict:
+    """指定期間内のパルスから level/peak/trend を算出。"""
+    pulses_in_window = [t for t in self._pulses if from_ts <= t <= to_ts]
+    level = min(100, int(len(pulses_in_window) / self.max_pulses * 100))
+    peak = level  # window内のピーク（将来的に細分化可）
+    return {"level": level, "peak": peak, "trend": self._calc_trend(level)}
+```
+
+### 2. Agitation Server の拡張（`agitation_server.py`）
+
+追加エンドポイント：
+
+```
+GET /agitation/window?from=<unix_sec>&to=<unix_sec>
+→ {"level": int, "peak": int, "trend": str}
+```
+
+### 3. Live API セッション管理（新規 `live_session.py`）
+
+```python
+class LiveSessionManager:
+    """Gemini Live API を使った占いセッション管理。"""
+
+    # セッション設定
+    MODEL = "gemini-2.5-flash-live"
+    TOOLS = [get_agitation_tool_declaration]
+
+    # 状態管理
+    _session: BidiGenerateContentSession
+    _ai_speak_start: float | None  # AI発話開始タイムスタンプ
+    _text_history: list[dict]      # 切断復帰用テキスト履歴（直近6ターン）
+
+    async def start(self): ...     # セッション確立
+    async def send_audio(self, pcm_bytes: bytes): ...  # ユーザー音声送信
+    async def receive(self) -> AsyncGenerator[dict, None]: ...  # 応答受信
+    async def _handle_tool_call(self, call) -> None:
+        # get_agitation() が呼ばれたとき
+        # window = [ai_speak_start, now] で agitation を取得して返す
+        ...
+```
+
+#### get_agitation tool 定義
+
+```python
+get_agitation_tool = {
+    "name": "get_agitation",
+    "description": (
+        "ユーザーの手の振動センサーから身体的動揺度を読み取る。"
+        "占いの重要なタイミング（感情の核心に触れる直前）で呼び出すこと。"
+        "呼び出すタイミング自体が演出の一部であり、"
+        "AI が最もドラマチックな瞬間を選ぶこと。"
+    ),
+    "parameters": {"type": "object", "properties": {}},
+    "behavior": "NON_BLOCKING",
+    "scheduling": "WHEN_IDLE",
+}
+```
+
+#### tool call 時のウィンドウ
+
+| タイミング | 取得ウィンドウ | 意味 |
+|---|---|---|
+| AI が tool call した時点 | `[ai_speak_start, now]` | AIが話し始めてからの反応 |
+
+### 4. バックエンドエンドポイント（`main.py`）
+
+```
+POST /api/session/start  → Live セッション確立、session_id を返す
+POST /api/audio          → PCM bytes 送信 → SSE で音声チャンク + イベントを返す
+DELETE /api/session      → セッション終了
+```
+
+音声チャンクは SSE で `audio_chunk` イベントとして送信（base64 PCM）。
+
+### 5. フロントエンド（`useSession.js`）
+
+変更点：
+- `new Audio(url)` による WAV 再生 → **Web Audio API** による PCM ストリーム再生
+- AI 発話開始タイムスタンプを `session_id` と共にバックエンドに通知
+- 音声チャンクを受け取り次第キューに追加して再生
+
+```javascript
+// PCM チャンク受信 → AudioBuffer に変換 → AudioContext でスケジュール再生
+const audioCtx = new AudioContext({ sampleRate: 24000 })
+```
+
+---
+
+## system_instruction（占い師プロンプト）
+
+Live API のセッション開始時に1回設定。
+
+```
+あなたはAI手相占い師「ぱむぱむ」です。
+
+【基本姿勢】
+手の感情線・運命線・頭脳線・生命線を具体的に言及しながら語る。
+断言は避け「〜ではないですか」「〜が見えます」という仮説として語る。
+神秘的かつ低いトーンで、2〜3文で語る。
+
+【get_agitation ツールの使い方（最重要）】
+- 毎ターン必ず1回呼び出すこと
+- 呼び出すタイミングは「感情の核心に近づいた」と感じた瞬間
+- 呼び出す前に一般的な読みを展開し、結果を見てから核心を突く
+- すぐに「センサーが〜」とは言わない。「体が正直に答えています」程度に留める
+
+【出力】
+2〜3文、必ず問いかけで締める。
+```
+
+---
+
+## 実装後タスク：プロンプトチューニング
+
+- agitation レベル別の応答トーン調整
+- tool call タイミングの誘導強化
+- コールドリーディング精度向上
+
+---
+
+## 変更ファイルサマリー
+
+| ファイル | 変更種別 | 規模 |
+|---|---|---|
+| `backend/src/agitation_engine.py` | 追加 | +20行 |
+| `backend/src/agitation_server.py` | 追加 | +10行 |
+| `backend/src/live_session.py` | 新規 | ~250行 |
+| `backend/src/two_stage_session.py` | 廃止（保持） | - |
+| `backend/src/main.py` | 変更 | ~60行変更 |
+| `frontend/src/hooks/useSession.js` | 変更 | ~100行変更 |
+
+合計：約 450〜500 行
+
+---
+
+## 技術的リスクと対策
+
+| リスク | 対策 |
+|---|---|
+| Live API セッション15分制限 | context window compression を有効化 |
+| セッション切断 | resumption token + テキスト履歴で復帰 |
+| tool call タイミングが不自然 | `WHEN_IDLE` + system_instruction で誘導 |
+| Web Audio API ブラウザ互換性 | Chrome/Safari の AudioContext で動作確認済み |
+| PCM フォーマット変換 | 入力: 16kHz mono / 出力: 24kHz mono で統一 |

--- a/frontend/public/pcm-processor.js
+++ b/frontend/public/pcm-processor.js
@@ -1,0 +1,21 @@
+/**
+ * AudioWorklet プロセッサ：マイク入力を 16kHz mono int16 PCM に変換して送信する。
+ * AudioContext sampleRate=16000 で使うこと。
+ */
+class PcmProcessor extends AudioWorkletProcessor {
+  process(inputs) {
+    const input = inputs[0]
+    if (!input || !input[0]) return true
+
+    const float32 = input[0]
+    const int16 = new Int16Array(float32.length)
+    for (let i = 0; i < float32.length; i++) {
+      int16[i] = Math.max(-32768, Math.min(32767, float32[i] * 32768))
+    }
+
+    this.port.postMessage(int16.buffer, [int16.buffer])
+    return true
+  }
+}
+
+registerProcessor('pcm-processor', PcmProcessor)

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -7,7 +7,7 @@ import { EndPage } from './pages/EndPage'
 
 export default function App() {
   const [page, setPage] = useState('title')
-  const { turn, vadError, timeLeft } = useSession({
+  const { turn, vadError } = useSession({
     enabled: page === 'session',
   })
 
@@ -19,7 +19,6 @@ export default function App() {
         <SessionPage
           turn={turn}
           vadError={vadError}
-          timeLeft={timeLeft}
           onEnd={() => setPage('end')}
         />
       )}

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -7,7 +7,7 @@ import { EndPage } from './pages/EndPage'
 
 export default function App() {
   const [page, setPage] = useState('title')
-  const { turn, aiText, vadError, timeLeft } = useSession({
+  const { turn, vadError, timeLeft } = useSession({
     enabled: page === 'session',
   })
 
@@ -18,7 +18,6 @@ export default function App() {
       {page === 'session' && (
         <SessionPage
           turn={turn}
-          aiText={aiText}
           vadError={vadError}
           timeLeft={timeLeft}
           onEnd={() => setPage('end')}

--- a/frontend/src/hooks/useSession.js
+++ b/frontend/src/hooks/useSession.js
@@ -3,72 +3,42 @@ import { useCallback, useEffect, useRef, useState } from 'react'
 const BACKEND_URL = import.meta.env.VITE_BACKEND_URL || ''
 const MAX_RECORD_SECONDS = 10
 
-async function* readSseStream(response) {
-  const reader = response.body.getReader()
-  const decoder = new TextDecoder()
-  let buffer = ''
-
-  while (true) {
-    const { done, value } = await reader.read()
-    if (done) break
-    buffer += decoder.decode(value, { stream: true })
-    const lines = buffer.split('\n')
-    buffer = lines.pop()
-    for (const line of lines) {
-      if (line.startsWith('data: ')) {
-        try {
-          yield JSON.parse(line.slice(6))
-        } catch {
-          // ignore
-        }
-      }
-    }
+function toWebSocketUrl(baseUrl) {
+  if (!baseUrl) {
+    const protocol = window.location.protocol === 'https:' ? 'wss:' : 'ws:'
+    return `${protocol}//${window.location.host}/ws/session`
   }
+  if (baseUrl.startsWith('https://')) {
+    return `wss://${baseUrl.slice('https://'.length)}/ws/session`
+  }
+  if (baseUrl.startsWith('http://')) {
+    return `ws://${baseUrl.slice('http://'.length)}/ws/session`
+  }
+  return `${baseUrl}/ws/session`
 }
 
 export function useSession({ enabled = false } = {}) {
   const [turn, setTurn] = useState('user')
   const [vadError, setVadError] = useState(null)
   const [timeLeft, setTimeLeft] = useState(MAX_RECORD_SECONDS)
+  const [sessionReady, setSessionReady] = useState(false)
 
-  const sessionIdRef = useRef(null)
+  const socketRef = useRef(null)
   const audioCtxRef = useRef(null)
   const captureCtxRef = useRef(null)
   const workletNodeRef = useRef(null)
   const streamRef = useRef(null)
-  const pcmChunksRef = useRef([])
   const nextPlayTimeRef = useRef(0)
   const countdownRef = useRef(null)
   const stopTimerRef = useRef(null)
   const enabledRef = useRef(enabled)
+  const moduleLoadedRef = useRef(false)
 
   useEffect(() => {
     enabledRef.current = enabled
   }, [enabled])
 
-  const startSession = useCallback(async () => {
-    try {
-      const response = await fetch(`${BACKEND_URL}/api/session/start`, { method: 'POST' })
-      const { session_id: sessionId } = await response.json()
-      sessionIdRef.current = sessionId
-      console.log('[useSession] session started:', sessionId)
-    } catch (err) {
-      setVadError(`セッション開始失敗: ${err.message}`)
-    }
-  }, [])
-
-  const stopSession = useCallback(async () => {
-    const sessionId = sessionIdRef.current
-    if (!sessionId) return
-    sessionIdRef.current = null
-    try {
-      await fetch(`${BACKEND_URL}/api/session?session_id=${sessionId}`, { method: 'DELETE' })
-    } catch {
-      // ignore
-    }
-  }, [])
-
-  const stopRecording = useCallback(async () => {
+  const clearTimers = useCallback(() => {
     if (countdownRef.current) {
       clearInterval(countdownRef.current)
       countdownRef.current = null
@@ -77,6 +47,40 @@ export function useSession({ enabled = false } = {}) {
       clearTimeout(stopTimerRef.current)
       stopTimerRef.current = null
     }
+  }, [])
+
+  const playAudioChunk = useCallback(async (base64Data) => {
+    if (!audioCtxRef.current || audioCtxRef.current.state === 'closed') {
+      audioCtxRef.current = new AudioContext({ sampleRate: 24000 })
+    }
+    const audioCtx = audioCtxRef.current
+    if (audioCtx.state === 'suspended') {
+      await audioCtx.resume()
+    }
+
+    const raw = atob(base64Data)
+    const int16 = new Int16Array(raw.length / 2)
+    for (let i = 0; i < int16.length; i++) {
+      int16[i] = raw.charCodeAt(i * 2) | (raw.charCodeAt(i * 2 + 1) << 8)
+    }
+
+    const float32 = new Float32Array(int16.length)
+    for (let i = 0; i < int16.length; i++) {
+      float32[i] = int16[i] / 32768
+    }
+
+    const buffer = audioCtx.createBuffer(1, float32.length, 24000)
+    buffer.copyToChannel(float32, 0)
+    const source = audioCtx.createBufferSource()
+    source.buffer = buffer
+    source.connect(audioCtx.destination)
+    const startAt = Math.max(audioCtx.currentTime, nextPlayTimeRef.current)
+    source.start(startAt)
+    nextPlayTimeRef.current = startAt + buffer.duration
+  }, [])
+
+  const stopRecording = useCallback(() => {
+    clearTimers()
     setTimeLeft(MAX_RECORD_SECONDS)
 
     const worklet = workletNodeRef.current
@@ -85,72 +89,11 @@ export function useSession({ enabled = false } = {}) {
       workletNodeRef.current = null
     }
 
-    const chunks = pcmChunksRef.current
-    pcmChunksRef.current = []
-    if (!enabledRef.current || chunks.length === 0) {
-      setTurn('user')
-      return
+    const socket = socketRef.current
+    if (socket?.readyState === WebSocket.OPEN) {
+      socket.send(JSON.stringify({ type: 'input_audio_end' }))
     }
-
-    const total = chunks.reduce((sum, chunk) => sum + chunk.length, 0)
-    const merged = new Int16Array(total)
-    let offset = 0
-    for (const chunk of chunks) {
-      merged.set(chunk, offset)
-      offset += chunk.length
-    }
-
-    const sessionId = sessionIdRef.current
-    if (!sessionId) {
-      setTurn('user')
-      return
-    }
-
-    setTurn('ai')
-
-    if (!audioCtxRef.current || audioCtxRef.current.state === 'closed') {
-      audioCtxRef.current = new AudioContext({ sampleRate: 24000 })
-    }
-    const audioCtx = audioCtxRef.current
-    nextPlayTimeRef.current = audioCtx.currentTime
-
-    try {
-      const response = await fetch(`${BACKEND_URL}/api/audio?session_id=${sessionId}`, {
-        method: 'POST',
-        headers: { 'Content-Type': 'audio/octet-stream' },
-        body: merged.buffer,
-      })
-      for await (const event of readSseStream(response)) {
-        if (event.type === 'audio_chunk') {
-          const raw = atob(event.data)
-          const int16 = new Int16Array(raw.length / 2)
-          for (let i = 0; i < int16.length; i++) {
-            int16[i] = raw.charCodeAt(i * 2) | (raw.charCodeAt(i * 2 + 1) << 8)
-          }
-
-          const float32 = new Float32Array(int16.length)
-          for (let i = 0; i < int16.length; i++) {
-            float32[i] = int16[i] / 32768
-          }
-
-          const buffer = audioCtx.createBuffer(1, float32.length, 24000)
-          buffer.copyToChannel(float32, 0)
-          const source = audioCtx.createBufferSource()
-          source.buffer = buffer
-          source.connect(audioCtx.destination)
-          const startAt = Math.max(audioCtx.currentTime, nextPlayTimeRef.current)
-          source.start(startAt)
-          nextPlayTimeRef.current = startAt + buffer.duration
-        } else if (event.type === 'turn_complete') {
-          const remaining = nextPlayTimeRef.current - audioCtx.currentTime
-          setTimeout(() => setTurn('user'), Math.max(0, remaining * 1000))
-        }
-      }
-    } catch (err) {
-      console.error('[useSession] sendAudio error:', err)
-      setTurn('user')
-    }
-  }, [])
+  }, [clearTimers])
 
   const startRecording = useCallback(async () => {
     setVadError(null)
@@ -166,18 +109,31 @@ export function useSession({ enabled = false } = {}) {
       }
       if (!captureCtxRef.current || captureCtxRef.current.state === 'closed') {
         captureCtxRef.current = new AudioContext({ sampleRate: 16000 })
+        moduleLoadedRef.current = false
       }
       const captureCtx = captureCtxRef.current
-      await captureCtx.audioWorklet.addModule('/pcm-processor.js')
+      if (!moduleLoadedRef.current) {
+        await captureCtx.audioWorklet.addModule('/pcm-processor.js')
+        moduleLoadedRef.current = true
+      }
 
       const source = captureCtx.createMediaStreamSource(streamRef.current)
       const worklet = new AudioWorkletNode(captureCtx, 'pcm-processor')
       workletNodeRef.current = worklet
 
-      pcmChunksRef.current = []
       worklet.port.onmessage = (event) => {
-        pcmChunksRef.current.push(new Int16Array(event.data))
+        const socket = socketRef.current
+        if (
+          !enabledRef.current ||
+          turn !== 'user' ||
+          !sessionReady ||
+          socket?.readyState !== WebSocket.OPEN
+        ) {
+          return
+        }
+        socket.send(event.data)
       }
+
       source.connect(worklet)
       worklet.connect(captureCtx.destination)
 
@@ -190,38 +146,90 @@ export function useSession({ enabled = false } = {}) {
     } catch (err) {
       setVadError(err?.message ?? 'マイク初期化失敗')
     }
-  }, [stopRecording])
+  }, [stopRecording, turn])
+
+  const startSession = useCallback(() => {
+    const socket = new WebSocket(toWebSocketUrl(BACKEND_URL))
+    socket.binaryType = 'arraybuffer'
+
+    socket.onmessage = (event) => {
+      try {
+        const message = JSON.parse(event.data)
+        if (message.type === 'session_ready') {
+          setSessionReady(true)
+          console.log('[useSession] session ready')
+          return
+        }
+        if (message.type === 'audio_chunk') {
+          setTurn('ai')
+          void playAudioChunk(message.data)
+          return
+        }
+        if (message.type === 'turn_complete') {
+          const audioCtx = audioCtxRef.current
+          const remaining = audioCtx ? nextPlayTimeRef.current - audioCtx.currentTime : 0
+          setTimeout(() => setTurn('user'), Math.max(0, remaining * 1000))
+          return
+        }
+        if (message.type === 'error') {
+          setVadError(message.message ?? 'セッションエラー')
+          setTurn('user')
+        }
+      } catch {
+        // ignore non-JSON frames
+      }
+    }
+
+    socket.onerror = () => {
+      setVadError('WebSocket 接続に失敗しました')
+    }
+    socket.onclose = () => {
+      setSessionReady(false)
+    }
+    socketRef.current = socket
+  }, [playAudioChunk])
+
+  const stopSession = useCallback(() => {
+    setSessionReady(false)
+    const socket = socketRef.current
+    socketRef.current = null
+    if (socket?.readyState === WebSocket.OPEN) {
+      socket.close()
+    }
+  }, [])
 
   useEffect(() => {
     if (!enabled) {
+      stopRecording()
       stopSession()
       setVadError(null)
+      setSessionReady(false)
       setTimeLeft(MAX_RECORD_SECONDS)
       setTurn('user')
       return
     }
+
     startSession()
-  }, [enabled, startSession, stopSession])
+  }, [enabled, startSession, stopRecording, stopSession])
 
   useEffect(() => {
-    if (!enabled) return
+    if (!enabled || !sessionReady) return
     if (turn === 'user') {
-      startRecording()
-    } else if (workletNodeRef.current) {
-      workletNodeRef.current.disconnect()
-      workletNodeRef.current = null
+      void startRecording()
+    } else {
+      stopRecording()
     }
-  }, [enabled, turn, startRecording])
+  }, [enabled, sessionReady, turn, startRecording, stopRecording])
 
   useEffect(() => {
     return () => {
-      if (countdownRef.current) clearInterval(countdownRef.current)
-      if (stopTimerRef.current) clearTimeout(stopTimerRef.current)
+      stopRecording()
+      stopSession()
       streamRef.current?.getTracks().forEach((track) => track.stop())
       captureCtxRef.current?.close()
       audioCtxRef.current?.close()
     }
-  }, [])
+  }, [stopRecording, stopSession])
 
   return { turn, vadError, timeLeft }
 }

--- a/frontend/src/hooks/useSession.js
+++ b/frontend/src/hooks/useSession.js
@@ -2,8 +2,6 @@ import { useCallback, useEffect, useRef, useState } from 'react'
 
 const BACKEND_URL = import.meta.env.VITE_BACKEND_URL || ''
 const MAX_RECORD_SECONDS = 10
-const SILENCE_THRESHOLD = 0.015
-const SILENCE_MS = 800
 
 function toWebSocketUrl(baseUrl) {
   if (!baseUrl) {
@@ -33,12 +31,10 @@ export function useSession({ enabled = false } = {}) {
   const nextPlayTimeRef = useRef(0)
   const countdownRef = useRef(null)
   const stopTimerRef = useRef(null)
-  const silenceTimerRef = useRef(null)
   const enabledRef = useRef(enabled)
   const moduleLoadedRef = useRef(false)
   const turnRef = useRef(turn)
   const sessionReadyRef = useRef(sessionReady)
-  const speechActiveRef = useRef(false)
 
   useEffect(() => {
     enabledRef.current = enabled
@@ -60,10 +56,6 @@ export function useSession({ enabled = false } = {}) {
     if (stopTimerRef.current) {
       clearTimeout(stopTimerRef.current)
       stopTimerRef.current = null
-    }
-    if (silenceTimerRef.current) {
-      clearTimeout(silenceTimerRef.current)
-      silenceTimerRef.current = null
     }
   }, [])
 
@@ -106,12 +98,6 @@ export function useSession({ enabled = false } = {}) {
       worklet.disconnect()
       workletNodeRef.current = null
     }
-
-    const socket = socketRef.current
-    if (socket?.readyState === WebSocket.OPEN) {
-      socket.send(JSON.stringify({ type: 'input_audio_end' }))
-    }
-    speechActiveRef.current = false
   }, [clearTimers])
 
   const startRecording = useCallback(async () => {
@@ -151,37 +137,7 @@ export function useSession({ enabled = false } = {}) {
         ) {
           return
         }
-
-        let sumSquares = 0
-        for (let i = 0; i < pcm.length; i++) {
-          const sample = pcm[i] / 32768
-          sumSquares += sample * sample
-        }
-        const rms = Math.sqrt(sumSquares / pcm.length)
-
-        if (rms >= SILENCE_THRESHOLD) {
-          speechActiveRef.current = true
-          if (silenceTimerRef.current) {
-            clearTimeout(silenceTimerRef.current)
-            silenceTimerRef.current = null
-          }
-          socket.send(event.data)
-          return
-        }
-
-        if (!speechActiveRef.current) {
-          return
-        }
-
         socket.send(event.data)
-        if (!silenceTimerRef.current) {
-          silenceTimerRef.current = setTimeout(() => {
-            silenceTimerRef.current = null
-            speechActiveRef.current = false
-            setTurn('ai')
-            stopRecording()
-          }, SILENCE_MS)
-        }
       }
 
       source.connect(worklet)

--- a/frontend/src/hooks/useSession.js
+++ b/frontend/src/hooks/useSession.js
@@ -29,16 +29,11 @@ export function useSession({ enabled = false } = {}) {
   const nextPlayTimeRef = useRef(0)
   const enabledRef = useRef(enabled)
   const moduleLoadedRef = useRef(false)
-  const turnRef = useRef(turn)
   const sessionReadyRef = useRef(sessionReady)
 
   useEffect(() => {
     enabledRef.current = enabled
   }, [enabled])
-
-  useEffect(() => {
-    turnRef.current = turn
-  }, [turn])
 
   useEffect(() => {
     sessionReadyRef.current = sessionReady
@@ -77,6 +72,7 @@ export function useSession({ enabled = false } = {}) {
   const stopRecording = useCallback(() => {
     const worklet = workletNodeRef.current
     if (worklet) {
+      worklet.port.onmessage = null
       worklet.disconnect()
       workletNodeRef.current = null
     }
@@ -108,15 +104,10 @@ export function useSession({ enabled = false } = {}) {
       const worklet = new AudioWorkletNode(captureCtx, 'pcm-processor')
       workletNodeRef.current = worklet
 
+      // PCM を常時送信。ターン管理は Gemini Live API の自動 VAD に委ねる
       worklet.port.onmessage = (event) => {
-        const pcm = new Int16Array(event.data)
         const socket = socketRef.current
-        if (
-          !enabledRef.current ||
-          turnRef.current !== 'user' ||
-          !sessionReadyRef.current ||
-          socket?.readyState !== WebSocket.OPEN
-        ) {
+        if (!enabledRef.current || !sessionReadyRef.current || socket?.readyState !== WebSocket.OPEN) {
           return
         }
         socket.send(event.data)
@@ -124,6 +115,7 @@ export function useSession({ enabled = false } = {}) {
 
       source.connect(worklet)
       worklet.connect(captureCtx.destination)
+      console.log('[useSession] recording started')
     } catch (err) {
       setVadError(err?.message ?? 'マイク初期化失敗')
     }
@@ -142,17 +134,20 @@ export function useSession({ enabled = false } = {}) {
           return
         }
         if (message.type === 'audio_chunk') {
+          console.log('[useSession] received audio_chunk')
           setTurn('ai')
           void playAudioChunk(message.data)
           return
         }
         if (message.type === 'turn_complete') {
+          console.log('[useSession] received turn_complete')
           const audioCtx = audioCtxRef.current
           const remaining = audioCtx ? nextPlayTimeRef.current - audioCtx.currentTime : 0
           setTimeout(() => setTurn('user'), Math.max(0, remaining * 1000))
           return
         }
         if (message.type === 'error') {
+          console.log('[useSession] received error', message)
           setVadError(message.message ?? 'セッションエラー')
           setTurn('user')
         }
@@ -162,9 +157,11 @@ export function useSession({ enabled = false } = {}) {
     }
 
     socket.onerror = () => {
+      console.log('[useSession] websocket error')
       setVadError('WebSocket 接続に失敗しました')
     }
-    socket.onclose = () => {
+    socket.onclose = (event) => {
+      console.log(`[useSession] websocket close code=${event.code} reason=${event.reason}`)
       setSessionReady(false)
     }
     socketRef.current = socket
@@ -180,6 +177,7 @@ export function useSession({ enabled = false } = {}) {
     }
   }, [])
 
+  // セッション開始/終了
   useEffect(() => {
     if (!enabled) {
       stopRecording()
@@ -193,14 +191,11 @@ export function useSession({ enabled = false } = {}) {
     startSession()
   }, [enabled, startSession, stopRecording, stopSession])
 
+  // session_ready になったら録音開始し、以後ずっと送信し続ける
   useEffect(() => {
     if (!enabled || !sessionReady) return
-    if (turn === 'user') {
-      void startRecording()
-    } else {
-      stopRecording()
-    }
-  }, [enabled, sessionReady, turn, startRecording, stopRecording])
+    void startRecording()
+  }, [enabled, sessionReady, startRecording])
 
   useEffect(() => {
     return () => {

--- a/frontend/src/hooks/useSession.js
+++ b/frontend/src/hooks/useSession.js
@@ -194,6 +194,7 @@ export function useSession({ enabled = false } = {}) {
     const socket = socketRef.current
     socketRef.current = null
     if (socket?.readyState === WebSocket.OPEN) {
+      socket.send(JSON.stringify({ type: 'session_end' }))
       socket.close()
     }
   }, [])

--- a/frontend/src/hooks/useSession.js
+++ b/frontend/src/hooks/useSession.js
@@ -2,6 +2,8 @@ import { useCallback, useEffect, useRef, useState } from 'react'
 
 const BACKEND_URL = import.meta.env.VITE_BACKEND_URL || ''
 const MAX_RECORD_SECONDS = 10
+const SILENCE_THRESHOLD = 0.015
+const SILENCE_MS = 800
 
 function toWebSocketUrl(baseUrl) {
   if (!baseUrl) {
@@ -31,12 +33,24 @@ export function useSession({ enabled = false } = {}) {
   const nextPlayTimeRef = useRef(0)
   const countdownRef = useRef(null)
   const stopTimerRef = useRef(null)
+  const silenceTimerRef = useRef(null)
   const enabledRef = useRef(enabled)
   const moduleLoadedRef = useRef(false)
+  const turnRef = useRef(turn)
+  const sessionReadyRef = useRef(sessionReady)
+  const speechActiveRef = useRef(false)
 
   useEffect(() => {
     enabledRef.current = enabled
   }, [enabled])
+
+  useEffect(() => {
+    turnRef.current = turn
+  }, [turn])
+
+  useEffect(() => {
+    sessionReadyRef.current = sessionReady
+  }, [sessionReady])
 
   const clearTimers = useCallback(() => {
     if (countdownRef.current) {
@@ -46,6 +60,10 @@ export function useSession({ enabled = false } = {}) {
     if (stopTimerRef.current) {
       clearTimeout(stopTimerRef.current)
       stopTimerRef.current = null
+    }
+    if (silenceTimerRef.current) {
+      clearTimeout(silenceTimerRef.current)
+      silenceTimerRef.current = null
     }
   }, [])
 
@@ -93,6 +111,7 @@ export function useSession({ enabled = false } = {}) {
     if (socket?.readyState === WebSocket.OPEN) {
       socket.send(JSON.stringify({ type: 'input_audio_end' }))
     }
+    speechActiveRef.current = false
   }, [clearTimers])
 
   const startRecording = useCallback(async () => {
@@ -122,16 +141,47 @@ export function useSession({ enabled = false } = {}) {
       workletNodeRef.current = worklet
 
       worklet.port.onmessage = (event) => {
+        const pcm = new Int16Array(event.data)
         const socket = socketRef.current
         if (
           !enabledRef.current ||
-          turn !== 'user' ||
-          !sessionReady ||
+          turnRef.current !== 'user' ||
+          !sessionReadyRef.current ||
           socket?.readyState !== WebSocket.OPEN
         ) {
           return
         }
+
+        let sumSquares = 0
+        for (let i = 0; i < pcm.length; i++) {
+          const sample = pcm[i] / 32768
+          sumSquares += sample * sample
+        }
+        const rms = Math.sqrt(sumSquares / pcm.length)
+
+        if (rms >= SILENCE_THRESHOLD) {
+          speechActiveRef.current = true
+          if (silenceTimerRef.current) {
+            clearTimeout(silenceTimerRef.current)
+            silenceTimerRef.current = null
+          }
+          socket.send(event.data)
+          return
+        }
+
+        if (!speechActiveRef.current) {
+          return
+        }
+
         socket.send(event.data)
+        if (!silenceTimerRef.current) {
+          silenceTimerRef.current = setTimeout(() => {
+            silenceTimerRef.current = null
+            speechActiveRef.current = false
+            setTurn('ai')
+            stopRecording()
+          }, SILENCE_MS)
+        }
       }
 
       source.connect(worklet)
@@ -146,7 +196,7 @@ export function useSession({ enabled = false } = {}) {
     } catch (err) {
       setVadError(err?.message ?? 'マイク初期化失敗')
     }
-  }, [stopRecording, turn])
+  }, [stopRecording])
 
   const startSession = useCallback(() => {
     const socket = new WebSocket(toWebSocketUrl(BACKEND_URL))

--- a/frontend/src/hooks/useSession.js
+++ b/frontend/src/hooks/useSession.js
@@ -1,7 +1,6 @@
 import { useCallback, useEffect, useRef, useState } from 'react'
 
 const BACKEND_URL = import.meta.env.VITE_BACKEND_URL || ''
-const MAX_RECORD_SECONDS = 10
 
 function toWebSocketUrl(baseUrl) {
   if (!baseUrl) {
@@ -20,7 +19,6 @@ function toWebSocketUrl(baseUrl) {
 export function useSession({ enabled = false } = {}) {
   const [turn, setTurn] = useState('user')
   const [vadError, setVadError] = useState(null)
-  const [timeLeft, setTimeLeft] = useState(MAX_RECORD_SECONDS)
   const [sessionReady, setSessionReady] = useState(false)
 
   const socketRef = useRef(null)
@@ -29,8 +27,6 @@ export function useSession({ enabled = false } = {}) {
   const workletNodeRef = useRef(null)
   const streamRef = useRef(null)
   const nextPlayTimeRef = useRef(0)
-  const countdownRef = useRef(null)
-  const stopTimerRef = useRef(null)
   const enabledRef = useRef(enabled)
   const moduleLoadedRef = useRef(false)
   const turnRef = useRef(turn)
@@ -47,17 +43,6 @@ export function useSession({ enabled = false } = {}) {
   useEffect(() => {
     sessionReadyRef.current = sessionReady
   }, [sessionReady])
-
-  const clearTimers = useCallback(() => {
-    if (countdownRef.current) {
-      clearInterval(countdownRef.current)
-      countdownRef.current = null
-    }
-    if (stopTimerRef.current) {
-      clearTimeout(stopTimerRef.current)
-      stopTimerRef.current = null
-    }
-  }, [])
 
   const playAudioChunk = useCallback(async (base64Data) => {
     if (!audioCtxRef.current || audioCtxRef.current.state === 'closed') {
@@ -90,15 +75,12 @@ export function useSession({ enabled = false } = {}) {
   }, [])
 
   const stopRecording = useCallback(() => {
-    clearTimers()
-    setTimeLeft(MAX_RECORD_SECONDS)
-
     const worklet = workletNodeRef.current
     if (worklet) {
       worklet.disconnect()
       workletNodeRef.current = null
     }
-  }, [clearTimers])
+  }, [])
 
   const startRecording = useCallback(async () => {
     setVadError(null)
@@ -142,13 +124,6 @@ export function useSession({ enabled = false } = {}) {
 
       source.connect(worklet)
       worklet.connect(captureCtx.destination)
-
-      setTimeLeft(MAX_RECORD_SECONDS)
-      countdownRef.current = setInterval(
-        () => setTimeLeft((value) => Math.max(0, value - 1)),
-        1000,
-      )
-      stopTimerRef.current = setTimeout(() => stopRecording(), MAX_RECORD_SECONDS * 1000)
     } catch (err) {
       setVadError(err?.message ?? 'マイク初期化失敗')
     }
@@ -211,7 +186,6 @@ export function useSession({ enabled = false } = {}) {
       stopSession()
       setVadError(null)
       setSessionReady(false)
-      setTimeLeft(MAX_RECORD_SECONDS)
       setTurn('user')
       return
     }
@@ -238,5 +212,5 @@ export function useSession({ enabled = false } = {}) {
     }
   }, [stopRecording, stopSession])
 
-  return { turn, vadError, timeLeft }
+  return { turn, vadError }
 }

--- a/frontend/src/hooks/useSession.js
+++ b/frontend/src/hooks/useSession.js
@@ -1,13 +1,13 @@
 import { useCallback, useEffect, useRef, useState } from 'react'
 
+const BACKEND_URL = import.meta.env.VITE_BACKEND_URL || ''
 const MAX_RECORD_SECONDS = 10
-const MICROPHONE_UNAVAILABLE_MESSAGE =
-  'この環境ではマイクが利用できません。HTTPS または localhost で開いてください。'
 
 async function* readSseStream(response) {
   const reader = response.body.getReader()
   const decoder = new TextDecoder()
   let buffer = ''
+
   while (true) {
     const { done, value } = await reader.read()
     if (done) break
@@ -28,40 +28,47 @@ async function* readSseStream(response) {
 
 export function useSession({ enabled = false } = {}) {
   const [turn, setTurn] = useState('user')
-  const [aiText, setAiText] = useState('')
   const [vadError, setVadError] = useState(null)
   const [timeLeft, setTimeLeft] = useState(MAX_RECORD_SECONDS)
 
+  const sessionIdRef = useRef(null)
+  const audioCtxRef = useRef(null)
+  const captureCtxRef = useRef(null)
+  const workletNodeRef = useRef(null)
   const streamRef = useRef(null)
-  const recorderRef = useRef(null)
-  const chunksRef = useRef([])
+  const pcmChunksRef = useRef([])
+  const nextPlayTimeRef = useRef(0)
   const countdownRef = useRef(null)
   const stopTimerRef = useRef(null)
   const enabledRef = useRef(enabled)
 
-  const audioQueueRef = useRef([])
-  const isPlayingRef = useRef(false)
-  const sseCompleteRef = useRef(false)
+  useEffect(() => {
+    enabledRef.current = enabled
+  }, [enabled])
 
-  const playNext = useCallback(() => {
-    if (isPlayingRef.current) return
-    const url = audioQueueRef.current.shift()
-    if (!url) {
-      if (sseCompleteRef.current) setTurn('user')
-      return
+  const startSession = useCallback(async () => {
+    try {
+      const response = await fetch(`${BACKEND_URL}/api/session/start`, { method: 'POST' })
+      const { session_id: sessionId } = await response.json()
+      sessionIdRef.current = sessionId
+      console.log('[useSession] session started:', sessionId)
+    } catch (err) {
+      setVadError(`セッション開始失敗: ${err.message}`)
     }
-    isPlayingRef.current = true
-    const audio = new Audio(url)
-    const onDone = () => {
-      isPlayingRef.current = false
-      playNext()
-    }
-    audio.onended = onDone
-    audio.onerror = onDone
-    audio.play().catch(onDone)
   }, [])
 
-  const clearTimers = useCallback(() => {
+  const stopSession = useCallback(async () => {
+    const sessionId = sessionIdRef.current
+    if (!sessionId) return
+    sessionIdRef.current = null
+    try {
+      await fetch(`${BACKEND_URL}/api/session?session_id=${sessionId}`, { method: 'DELETE' })
+    } catch {
+      // ignore
+    }
+  }, [])
+
+  const stopRecording = useCallback(async () => {
     if (countdownRef.current) {
       clearInterval(countdownRef.current)
       countdownRef.current = null
@@ -70,153 +77,151 @@ export function useSession({ enabled = false } = {}) {
       clearTimeout(stopTimerRef.current)
       stopTimerRef.current = null
     }
-  }, [])
+    setTimeLeft(MAX_RECORD_SECONDS)
 
-  const resetPlaybackState = useCallback(() => {
-    audioQueueRef.current = []
-    isPlayingRef.current = false
-    sseCompleteRef.current = false
-  }, [])
+    const worklet = workletNodeRef.current
+    if (worklet) {
+      worklet.disconnect()
+      workletNodeRef.current = null
+    }
 
-  const startRecording = useCallback(async () => {
-    setVadError(null)
-    const mediaDevices = globalThis.navigator?.mediaDevices
-    if (!mediaDevices?.getUserMedia || typeof MediaRecorder === 'undefined') {
-      setVadError(MICROPHONE_UNAVAILABLE_MESSAGE)
+    const chunks = pcmChunksRef.current
+    pcmChunksRef.current = []
+    if (!enabledRef.current || chunks.length === 0) {
+      setTurn('user')
       return
     }
-    try {
-      if (!streamRef.current) {
-        streamRef.current = await mediaDevices.getUserMedia({ audio: true })
-      }
-      const preferredType = 'audio/webm;codecs=opus'
-      const options = MediaRecorder.isTypeSupported(preferredType)
-        ? { mimeType: preferredType }
-        : undefined
-      const recorder = new MediaRecorder(streamRef.current, options)
-      recorderRef.current = recorder
-      chunksRef.current = []
 
-      recorder.ondataavailable = (e) => {
-        if (e.data?.size > 0) chunksRef.current.push(e.data)
-      }
-      recorder.onerror = (e) => setVadError(e.error?.message ?? '録音エラー')
-      recorder.onstop = async () => {
-        clearTimers()
-        setTimeLeft(MAX_RECORD_SECONDS)
-        const blob = new Blob(chunksRef.current, {
-          type: recorder.mimeType || 'audio/webm',
-        })
-        chunksRef.current = []
-        if (!enabledRef.current) {
-          return
-        }
-        if (blob.size > 0) {
-          await sendAudioRef.current?.(blob, recorder.mimeType || 'audio/webm')
-        } else {
-          setTurn('user')
-        }
-      }
-
-      recorder.start()
-      setTimeLeft(MAX_RECORD_SECONDS)
-      countdownRef.current = setInterval(
-        () => setTimeLeft((t) => Math.max(0, t - 1)),
-        1000,
-      )
-      stopTimerRef.current = setTimeout(() => {
-        if (recorderRef.current?.state === 'recording') recorderRef.current.stop()
-      }, MAX_RECORD_SECONDS * 1000)
-    } catch (err) {
-      setVadError(err?.message ?? 'マイク初期化失敗')
+    const total = chunks.reduce((sum, chunk) => sum + chunk.length, 0)
+    const merged = new Int16Array(total)
+    let offset = 0
+    for (const chunk of chunks) {
+      merged.set(chunk, offset)
+      offset += chunk.length
     }
-  }, [clearTimers])
 
-  const sendAudioRef = useRef(null)
+    const sessionId = sessionIdRef.current
+    if (!sessionId) {
+      setTurn('user')
+      return
+    }
 
-  useEffect(() => {
-    enabledRef.current = enabled
-  }, [enabled])
-
-  const sendAudio = useCallback(async (blob, mimeType) => {
-    resetPlaybackState()
     setTurn('ai')
-    setAiText('')
+
+    if (!audioCtxRef.current || audioCtxRef.current.state === 'closed') {
+      audioCtxRef.current = new AudioContext({ sampleRate: 24000 })
+    }
+    const audioCtx = audioCtxRef.current
+    nextPlayTimeRef.current = audioCtx.currentTime
 
     try {
-      const response = await fetch('/api/audio', {
+      const response = await fetch(`${BACKEND_URL}/api/audio?session_id=${sessionId}`, {
         method: 'POST',
-        headers: { 'Content-Type': mimeType },
-        body: blob,
+        headers: { 'Content-Type': 'audio/octet-stream' },
+        body: merged.buffer,
       })
       for await (const event of readSseStream(response)) {
-        if (event.type === 'stage1' || event.type === 'stage2') {
-          setAiText((prev) => prev + event.text)
-          if (event.audio_url) {
-            audioQueueRef.current.push(event.audio_url)
-            playNext()
+        if (event.type === 'audio_chunk') {
+          const raw = atob(event.data)
+          const int16 = new Int16Array(raw.length / 2)
+          for (let i = 0; i < int16.length; i++) {
+            int16[i] = raw.charCodeAt(i * 2) | (raw.charCodeAt(i * 2 + 1) << 8)
           }
-        } else if (event.type === 'turn_end') {
-          sseCompleteRef.current = true
-          if (!isPlayingRef.current && audioQueueRef.current.length === 0) {
-            setTurn('user')
+
+          const float32 = new Float32Array(int16.length)
+          for (let i = 0; i < int16.length; i++) {
+            float32[i] = int16[i] / 32768
           }
+
+          const buffer = audioCtx.createBuffer(1, float32.length, 24000)
+          buffer.copyToChannel(float32, 0)
+          const source = audioCtx.createBufferSource()
+          source.buffer = buffer
+          source.connect(audioCtx.destination)
+          const startAt = Math.max(audioCtx.currentTime, nextPlayTimeRef.current)
+          source.start(startAt)
+          nextPlayTimeRef.current = startAt + buffer.duration
+        } else if (event.type === 'turn_complete') {
+          const remaining = nextPlayTimeRef.current - audioCtx.currentTime
+          setTimeout(() => setTurn('user'), Math.max(0, remaining * 1000))
         }
       }
     } catch (err) {
       console.error('[useSession] sendAudio error:', err)
       setTurn('user')
     }
-  }, [playNext, resetPlaybackState])
+  }, [])
 
-  useEffect(() => {
-    sendAudioRef.current = sendAudio
-  }, [sendAudio])
-
-  const startRecordingRef = useRef(startRecording)
-
-  useEffect(() => {
-    startRecordingRef.current = startRecording
-  }, [startRecording])
-
-  useEffect(() => {
-    if (!enabled) {
-      clearTimers()
-      if (recorderRef.current?.state === 'recording') recorderRef.current.stop()
+  const startRecording = useCallback(async () => {
+    setVadError(null)
+    const mediaDevices = globalThis.navigator?.mediaDevices
+    if (!mediaDevices?.getUserMedia) {
+      setVadError('マイクが利用できません。HTTPS または localhost で開いてください。')
       return
     }
-    if (turn === 'user') {
-      startRecordingRef.current()
-    } else {
-      clearTimers()
-      if (recorderRef.current?.state === 'recording') recorderRef.current.stop()
+
+    try {
+      if (!streamRef.current) {
+        streamRef.current = await mediaDevices.getUserMedia({ audio: true })
+      }
+      if (!captureCtxRef.current || captureCtxRef.current.state === 'closed') {
+        captureCtxRef.current = new AudioContext({ sampleRate: 16000 })
+      }
+      const captureCtx = captureCtxRef.current
+      await captureCtx.audioWorklet.addModule('/pcm-processor.js')
+
+      const source = captureCtx.createMediaStreamSource(streamRef.current)
+      const worklet = new AudioWorkletNode(captureCtx, 'pcm-processor')
+      workletNodeRef.current = worklet
+
+      pcmChunksRef.current = []
+      worklet.port.onmessage = (event) => {
+        pcmChunksRef.current.push(new Int16Array(event.data))
+      }
+      source.connect(worklet)
+      worklet.connect(captureCtx.destination)
+
+      setTimeLeft(MAX_RECORD_SECONDS)
+      countdownRef.current = setInterval(
+        () => setTimeLeft((value) => Math.max(0, value - 1)),
+        1000,
+      )
+      stopTimerRef.current = setTimeout(() => stopRecording(), MAX_RECORD_SECONDS * 1000)
+    } catch (err) {
+      setVadError(err?.message ?? 'マイク初期化失敗')
     }
-  }, [enabled, turn, clearTimers])
+  }, [stopRecording])
 
   useEffect(() => {
     if (!enabled) {
-      clearTimers()
+      stopSession()
       setVadError(null)
       setTimeLeft(MAX_RECORD_SECONDS)
-      resetPlaybackState()
-      setAiText('')
       setTurn('user')
       return
     }
-    setVadError(null)
-    setTimeLeft(MAX_RECORD_SECONDS)
-    resetPlaybackState()
-    setAiText('')
-    setTurn('user')
-  }, [enabled, clearTimers, resetPlaybackState])
+    startSession()
+  }, [enabled, startSession, stopSession])
+
+  useEffect(() => {
+    if (!enabled) return
+    if (turn === 'user') {
+      startRecording()
+    } else if (workletNodeRef.current) {
+      workletNodeRef.current.disconnect()
+      workletNodeRef.current = null
+    }
+  }, [enabled, turn, startRecording])
 
   useEffect(() => {
     return () => {
-      clearTimers()
-      if (recorderRef.current?.state === 'recording') recorderRef.current.stop()
-      streamRef.current?.getTracks().forEach((t) => t.stop())
+      if (countdownRef.current) clearInterval(countdownRef.current)
+      if (stopTimerRef.current) clearTimeout(stopTimerRef.current)
+      streamRef.current?.getTracks().forEach((track) => track.stop())
+      captureCtxRef.current?.close()
+      audioCtxRef.current?.close()
     }
-  }, [clearTimers])
+  }, [])
 
-  return { turn, aiText, vadError, timeLeft }
+  return { turn, vadError, timeLeft }
 }

--- a/frontend/src/pages/SessionPage.jsx
+++ b/frontend/src/pages/SessionPage.jsx
@@ -3,7 +3,7 @@ import { KirbyMock } from '../components/KirbyMock'
 
 const SESSION_SECONDS = 120
 
-export function SessionPage({ turn, aiText, vadError, timeLeft, onEnd }) {
+export function SessionPage({ turn, vadError, timeLeft, onEnd }) {
   const [sessionTimeLeft, setSessionTimeLeft] = useState(SESSION_SECONDS)
 
   useEffect(() => {
@@ -30,10 +30,8 @@ export function SessionPage({ turn, aiText, vadError, timeLeft, onEnd }) {
           🎤 話してください... 残り {timeLeft}s
         </div>
       )}
-      <KirbyMock isTalking={turn === 'ai' && aiText.length > 0} />
-      <div className="mt-8 max-w-md text-center min-h-[4rem] px-4">
-        <p className="text-lg leading-relaxed">{aiText}</p>
-      </div>
+      <KirbyMock isTalking={turn === 'ai'} />
+      <div className="mt-8 max-w-md text-center min-h-[4rem] px-4" />
     </div>
   )
 }

--- a/frontend/src/pages/SessionPage.jsx
+++ b/frontend/src/pages/SessionPage.jsx
@@ -3,7 +3,7 @@ import { KirbyMock } from '../components/KirbyMock'
 
 const SESSION_SECONDS = 120
 
-export function SessionPage({ turn, vadError, timeLeft, onEnd }) {
+export function SessionPage({ turn, vadError, onEnd }) {
   const [sessionTimeLeft, setSessionTimeLeft] = useState(SESSION_SECONDS)
 
   useEffect(() => {
@@ -27,7 +27,7 @@ export function SessionPage({ turn, vadError, timeLeft, onEnd }) {
       )}
       {turn === 'user' && (
         <div className="absolute bottom-4 left-1/2 -translate-x-1/2 text-sm text-red-400 bg-black/60 px-3 py-1 rounded">
-          🎤 話してください... 残り {timeLeft}s
+          🎤 話してください...
         </div>
       )}
       <KirbyMock isTalking={turn === 'ai'} />


### PR DESCRIPTION
## Summary

- Gemini Live API への WebSocket ストリーミング移行（`POST /api/audio + SSE` から完全移行）
- 2ターン目以降に応答が返らないバグを修正（SDKの `receive()` が1ターン分で終了する仕様への対応）
- クライアント側 silence 検出を廃止し、Gemini Live API の自動 VAD に一本化

## 主な変更

### バグ修正
- `live_session.py`: `receive()` を `while True:` でラップし、ターンをまたいで SDK の `session.receive()` を再呼び出しするよう修正

### 自動VAD対応
- `live_session.py`: `automatic_activity_detection.disabled=True` を削除して Gemini の自動 VAD を有効化
- `useSession.js`: silence 検出・`input_audio_end` 自動送信・`awaitingResponseRef` を削除し、PCM を常時送信
- `main.py`: `input_audio_start` ハンドラを削除（Live VAD が代替）

### アーキテクチャ
- ブラウザ AudioWorklet → WebSocket binary frame → Gemini Live API の常時ストリーミング
- ターン制御は `turn_complete` イベントのみで管理
- AI 発話中もPCM送信継続し、割り込みを Live API に委ねる

## Test plan

- [x] `uv run pytest tests/ -v` → 77 passed
- [x] `npm run build` → success
- [x] ローカル実機確認（2ターン目以降の応答確認済み）

🤖 Generated with [Claude Code](https://claude.com/claude-code)